### PR TITLE
Fixing squid:S1118 -  Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/alibaba/ttl/threadpool/agent/TtlAgent.java
+++ b/src/main/java/com/alibaba/ttl/threadpool/agent/TtlAgent.java
@@ -11,9 +11,13 @@ import java.util.logging.Logger;
  * @see <a href="http://docs.oracle.com/javase/7/docs/api/java/lang/instrument/package-summary.html">The mechanism for instrumentation</a>
  * @since 0.9.0
  */
-public class TtlAgent {
+public final class TtlAgent {
     private static final Logger logger = Logger.getLogger(TtlAgent.class.getName());
-
+    
+    private TtlAgent() {
+    	throw new InstantiationError( "Must not instantiate this class" );
+    }
+    
     public static void premain(String agentArgs, Instrumentation inst) {
         logger.info("[TtlAgent.premain] begin, agentArgs: " + agentArgs);
         install(agentArgs, inst);

--- a/src/test/java/com/alibaba/ttl/Utils.java
+++ b/src/test/java/com/alibaba/ttl/Utils.java
@@ -14,11 +14,15 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Jerry Lee (oldratlee at gmail dot com)
  */
-public class Utils {
+public final class Utils {
     public static final String PARENT_UNMODIFIED_IN_CHILD = "parent-created-unmodified-in-child";
     public static final String PARENT_MODIFIED_IN_CHILD = "parent-created-modified-in-child";
     public static final String PARENT_AFTER_CREATE_TTL_TASK = "parent-created-after-create-TtlTask";
     public static final String CHILD = "child-created";
+    
+    private Utils() {
+    	throw new InstantiationError( "Must not instantiate this class" );
+    }
 
     public static ConcurrentMap<String, TransmittableThreadLocal<String>> createTestTtlValue() {
         ConcurrentMap<String, TransmittableThreadLocal<String>> ttlInstances = new ConcurrentHashMap<String, TransmittableThreadLocal<String>>();

--- a/src/test/java/com/alibaba/ttl/demo/distributed_tracer/DistributedTracerUseDemo.java
+++ b/src/test/java/com/alibaba/ttl/demo/distributed_tracer/DistributedTracerUseDemo.java
@@ -13,7 +13,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author Jerry Lee (oldratlee at gmail dot com)
  */
-public class DistributedTracerUseDemo {
+public final class DistributedTracerUseDemo {
+	
+	private DistributedTracerUseDemo() {
+	    	throw new InstantiationError( "Must not instantiate this class" );
+	}
     static ThreadFactory threadFactory = new ThreadFactory() {
         @Override
         public Thread newThread(Runnable r) {

--- a/src/test/java/com/alibaba/ttl/demo/distributed_tracer/DistributedTracerUseDemo_WeakReferenceInsteadOfRefCounter.java
+++ b/src/test/java/com/alibaba/ttl/demo/distributed_tracer/DistributedTracerUseDemo_WeakReferenceInsteadOfRefCounter.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * @author Jerry Lee (oldratlee at gmail dot com)
  */
-public class DistributedTracerUseDemo_WeakReferenceInsteadOfRefCounter {
+public final class DistributedTracerUseDemo_WeakReferenceInsteadOfRefCounter {
     static ThreadFactory threadFactory = new ThreadFactory() {
         @Override
         public Thread newThread(Runnable r) {
@@ -30,6 +30,10 @@ public class DistributedTracerUseDemo_WeakReferenceInsteadOfRefCounter {
 
     static ExecutorService executorService = TtlExecutors.getTtlExecutorService(Executors.newFixedThreadPool(1, threadFactory));
 
+    private DistributedTracerUseDemo_WeakReferenceInsteadOfRefCounter() {
+    	throw new InstantiationError( "Must not instantiate this class" );
+    }
+    
     static {
         // 挤满线程, 保证线程不是用的时候new的, 确保验证TTL的传递功能
         Utils.expandThreadPool(executorService);

--- a/src/test/java/com/alibaba/ttl/perf/memoryleak/NoMemoryLeak_ThreadLocal_NoRemove.java
+++ b/src/test/java/com/alibaba/ttl/perf/memoryleak/NoMemoryLeak_ThreadLocal_NoRemove.java
@@ -5,7 +5,12 @@ import com.alibaba.ttl.perf.Utils;
 /**
  * @author Jerry Lee (oldratlee at gmail dot com)
  */
-public class NoMemoryLeak_ThreadLocal_NoRemove {
+public final class NoMemoryLeak_ThreadLocal_NoRemove {
+	
+	private NoMemoryLeak_ThreadLocal_NoRemove() {
+	   	throw new InstantiationError( "Must not instantiate this class" );
+	}
+	
     public static void main(String[] args) throws Exception {
         long counter = 0;
         while (true) {

--- a/src/test/java/com/alibaba/ttl/perf/tps/CreateThreadLocalInstanceTps.java
+++ b/src/test/java/com/alibaba/ttl/perf/tps/CreateThreadLocalInstanceTps.java
@@ -5,7 +5,12 @@ import com.alibaba.ttl.perf.Utils;
 /**
  * @author Jerry Lee (oldratlee at gmail dot com)
  */
-public class CreateThreadLocalInstanceTps {
+public final class CreateThreadLocalInstanceTps {
+	 
+	private CreateThreadLocalInstanceTps() {
+	   	throw new InstantiationError( "Must not instantiate this class" );
+	}
+	 
     public static void main(String[] args) throws Exception {
         TpsCounter tpsCounter = new TpsCounter(2);
         tpsCounter.run(new Runnable() {

--- a/src/test/java/com/alibaba/ttl/threadpool/agent/AgentCheck.java
+++ b/src/test/java/com/alibaba/ttl/threadpool/agent/AgentCheck.java
@@ -23,10 +23,13 @@ import static com.alibaba.ttl.Utils.expandThreadPool;
 /**
  * @author Jerry Lee (oldratlee at gmail dot com)
  */
-public class AgentCheck {
+public final class AgentCheck {
     static ExecutorService executorService = Executors.newFixedThreadPool(3);
     static ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(3);
 
+    private AgentCheck() {
+    	throw new InstantiationError( "Must not instantiate this class" );
+    }
     static {
         expandThreadPool(executorService);
         expandThreadPool(scheduledExecutorService);

--- a/src/test/java/com/alibaba/ttl/threadpool/agent/demo/AgentDemo.java
+++ b/src/test/java/com/alibaba/ttl/threadpool/agent/demo/AgentDemo.java
@@ -11,7 +11,8 @@ import java.util.concurrent.Future;
 /**
  * @author Jerry Lee (oldratlee at gmail dot com)
  */
-public class AgentDemo {
+public final class AgentDemo {
+	
     static TransmittableThreadLocal<String> stringTransmittableThreadLocal = new TransmittableThreadLocal<String>();
 
     static TransmittableThreadLocal<Person> personReferenceTransmittableThreadLocal = new TransmittableThreadLocal<Person>() {
@@ -33,6 +34,10 @@ public class AgentDemo {
             return new Person("unnamed", -1);
         }
     };
+    
+    private AgentDemo() {
+    	throw new InstantiationError( "Must not instantiate this class" );
+    }
 
     public static void main(String[] args) throws Exception {
         ExecutorService executorService = Executors.newFixedThreadPool(3);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1118 -  Utility classes should not have public constructors". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1118


Please let me know if you have any questions.
Sameer Misger