### PR TITLE
Fixing squid:S2275 -  Printf-style format strings should not lead to unexpected behavior at runtime

### DIFF
--- a/src/test/java/com/alibaba/ttl/Utils.java
+++ b/src/test/java/com/alibaba/ttl/Utils.java
@@ -65,7 +65,7 @@ public class Utils {
         for (Map.Entry<String, TransmittableThreadLocal<T>> entry : ttlInstances.entrySet()) {
             String key = entry.getKey();
             T value = entry.getValue().get();
-            System.out.printf("Key %s, value: %s\n", key, value);
+            System.out.printf("Key %s, value: %s%n", key, value);
         }
     }
 

--- a/src/test/java/com/alibaba/ttl/demo/distributed_tracer/DistributedTracerUseDemo.java
+++ b/src/test/java/com/alibaba/ttl/demo/distributed_tracer/DistributedTracerUseDemo.java
@@ -81,7 +81,7 @@ public class DistributedTracerUseDemo {
         String traceId = dtTransferInfo.traceId;
         int refCounter = traceId2LeafSpanIdInfo.get(traceId).refCounter.incrementAndGet();
 
-        System.out.printf("DEBUG: Increase reference counter(%s) for traceId %s in thread %s\n", refCounter, traceId, Thread.currentThread().getName());
+        System.out.printf("DEBUG: Increase reference counter(%s) for traceId %s in thread %s%n", refCounter, traceId, Thread.currentThread().getName());
     }
 
     static void decreaseSpanIdRefCounter() {
@@ -90,12 +90,12 @@ public class DistributedTracerUseDemo {
         LeafSpanIdInfo leafSpanIdInfo = traceId2LeafSpanIdInfo.get(traceId);
 
         int refCounter = leafSpanIdInfo.refCounter.decrementAndGet();
-        System.out.printf("DEBUG: Decrease reference counter(%s) for traceId %s in thread %s\n", refCounter, traceId, Thread.currentThread().getName());
+        System.out.printf("DEBUG: Decrease reference counter(%s) for traceId %s in thread %s%n", refCounter, traceId, Thread.currentThread().getName());
 
         if (refCounter == 0) {
             traceId2LeafSpanIdInfo.remove(traceId);
 
-            System.out.printf("DEBUG: Clear traceId2LeafSpanIdInfo for traceId %s in thread %s\n", traceId, Thread.currentThread().getName());
+            System.out.printf("DEBUG: Clear traceId2LeafSpanIdInfo for traceId %s in thread %s%n", traceId, Thread.currentThread().getName());
         } else if (refCounter < 0) {
             throw new IllegalStateException("Leaf Span Id Info Reference counter has Bug!!");
         }
@@ -188,6 +188,6 @@ public class DistributedTracerUseDemo {
 
         // Do Rpc
         // ...
-        System.out.printf("Do Rpc invocation to server %s with %s\n", server, rpcContext);
+        System.out.printf("Do Rpc invocation to server %s with %s%n", server, rpcContext);
     }
 }

--- a/src/test/java/com/alibaba/ttl/demo/distributed_tracer/DistributedTracerUseDemo_WeakReferenceInsteadOfRefCounter.java
+++ b/src/test/java/com/alibaba/ttl/demo/distributed_tracer/DistributedTracerUseDemo_WeakReferenceInsteadOfRefCounter.java
@@ -58,7 +58,7 @@ public class DistributedTracerUseDemo_WeakReferenceInsteadOfRefCounter {
         // Output GC operation
         @Override
         protected void finalize() throws Throwable {
-            System.out.printf("DEBUG: gc DtTransferInfo traceId %s in thread %s: %s\n",
+            System.out.printf("DEBUG: gc DtTransferInfo traceId %s in thread %s: %s%n",
                     traceId, Thread.currentThread().getName(), this);
             super.finalize();
         }
@@ -119,7 +119,7 @@ public class DistributedTracerUseDemo_WeakReferenceInsteadOfRefCounter {
         ////////////////////////////////////////////////
         // DistributedTracer Framework Code
         ////////////////////////////////////////////////
-        System.out.printf("Finished Rpc call %s with span %s.\n", traceId, leafSpanIdInfo);
+        System.out.printf("Finished Rpc call %s with span %s.%n", traceId, leafSpanIdInfo);
 
         // release context in ThreadLocal, avoid to be hold by thread, GC friendly.
         transferInfo.remove();
@@ -171,6 +171,6 @@ public class DistributedTracerUseDemo_WeakReferenceInsteadOfRefCounter {
 
         // Do Rpc
         // ...
-        System.out.printf("Do Rpc invocation to server %s with %s\n", server, rpcContext);
+        System.out.printf("Do Rpc invocation to server %s with %s%n", server, rpcContext);
     }
 }

--- a/src/test/java/com/alibaba/ttl/perf/memoryleak/NoMemoryLeak_ThreadLocal_NoRemove.java
+++ b/src/test/java/com/alibaba/ttl/perf/memoryleak/NoMemoryLeak_ThreadLocal_NoRemove.java
@@ -13,7 +13,7 @@ public class NoMemoryLeak_ThreadLocal_NoRemove {
             threadLocal.set(Utils.getRandomString());
 
             if (counter % 1000 == 0)
-                System.out.printf("%05dK\n", counter / 1000);
+                System.out.printf("%05dK%n", counter / 1000);
             counter++;
         }
     }

--- a/src/test/java/com/alibaba/ttl/perf/memoryleak/NoMemoryLeak_TransmittableThreadLocal_NoRemove.java
+++ b/src/test/java/com/alibaba/ttl/perf/memoryleak/NoMemoryLeak_TransmittableThreadLocal_NoRemove.java
@@ -14,7 +14,7 @@ public class NoMemoryLeak_TransmittableThreadLocal_NoRemove {
             threadLocal.set(Utils.getRandomString());
 
             if (counter % 1000 == 0)
-                System.out.printf("%05dK\n", counter / 1000);
+                System.out.printf("%05dK%n", counter / 1000);
             counter++;
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S2275

Please let me know if you have any questions.
Sameer Misger