### PR TITLE
support ForkJoinPool of jdk 7/7+ #76

### DIFF
--- a/src/main/java/com/alibaba/ttl/TtlRecursiveAction.java
+++ b/src/main/java/com/alibaba/ttl/TtlRecursiveAction.java
@@ -1,0 +1,69 @@
+package com.alibaba.ttl;
+
+import java.util.Map;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A recursive resultless {@link ForkJoinTask} enhanced by {@link TransmittableThreadLocal}.
+ * This class establishes conventions to parameterize resultless actions as
+ * {@code Void} {@code ForkJoinTask}s. Because {@code null} is the
+ * only valid value of type {@code Void}, methods such as {@code join}
+ * always return {@code null} upon completion.
+ *
+ * @author LNAmp
+ * @see java.util.concurrent.RecursiveAction
+ * @since 2.3.0
+ */
+public abstract class TtlRecursiveAction extends ForkJoinTask<Void> {
+
+    private static final long serialVersionUID = -5753568484583412377L;
+
+    protected final boolean releaseTtlValueReferenceAfterCall;
+
+    protected final AtomicReference<Map<TransmittableThreadLocal<?>, Object>> copiedRef
+        = new AtomicReference<Map<TransmittableThreadLocal<?>, Object>>(TransmittableThreadLocal.copy());
+
+    protected TtlRecursiveAction() {
+        this(false);
+    }
+
+    protected TtlRecursiveAction(boolean releaseTtlValueReferenceAfterCall) {
+        this.releaseTtlValueReferenceAfterCall = releaseTtlValueReferenceAfterCall;
+    }
+
+    /**
+     * The main computation performed by this task.
+     */
+    protected abstract void compute();
+
+    /**
+     * Always returns {@code null}.
+     *
+     * @return {@code null} always
+     */
+    public final Void getRawResult() { return null; }
+
+    /**
+     * Requires null completion value.
+     */
+    protected final void setRawResult(Void mustBeNull) { }
+
+    /**
+     * Implements execution conventions for RecursiveActions.
+     */
+    protected final boolean exec() {
+        Map<TransmittableThreadLocal<?>, Object> copied = copiedRef.get();
+        if (copied == null || releaseTtlValueReferenceAfterCall && !copiedRef.compareAndSet(copied, null)) {
+            throw new IllegalStateException("TTL value reference is released after call!");
+        }
+
+        Map<TransmittableThreadLocal<?>, Object> backup = TransmittableThreadLocal.backupAndSetToCopied(copied);
+        try {
+            compute();
+            return true;
+        } finally {
+            TransmittableThreadLocal.restoreBackup(backup);
+        }
+    }
+}

--- a/src/main/java/com/alibaba/ttl/TtlRecursiveTask.java
+++ b/src/main/java/com/alibaba/ttl/TtlRecursiveTask.java
@@ -1,0 +1,70 @@
+package com.alibaba.ttl;
+
+import java.util.Map;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A recursive result-bearing {@link ForkJoinTask} enhanced by {@link TransmittableThreadLocal}.
+ *
+ *
+ * @see java.util.concurrent.RecursiveTask
+ * @author LNAmp
+ * @since 2.3.0
+ */
+public abstract class TtlRecursiveTask<V> extends ForkJoinTask<V> {
+
+    private static final long serialVersionUID = 1814679366926362436L;
+
+    protected final boolean releaseTtlValueReferenceAfterCall;
+
+    protected final AtomicReference<Map<TransmittableThreadLocal<?>, Object>> copiedRef
+        = new AtomicReference<Map<TransmittableThreadLocal<?>, Object>>(TransmittableThreadLocal.copy());
+
+    protected TtlRecursiveTask() {
+        this(false);
+    }
+
+    protected TtlRecursiveTask(boolean releaseTtlValueReferenceAfterCall) {
+        this.releaseTtlValueReferenceAfterCall = releaseTtlValueReferenceAfterCall;
+    }
+
+
+    /**
+     * The result of the computation.
+     */
+    V result;
+
+    /**
+     * The main computation performed by this task.
+     * @return the result of the computation
+     */
+    protected abstract V compute();
+
+    public final V getRawResult() {
+        return result;
+    }
+
+    protected final void setRawResult(V value) {
+        result = value;
+    }
+
+    /**
+     * Implements execution conventions for RecursiveTask.
+     */
+    protected final boolean exec() {
+        Map<TransmittableThreadLocal<?>, Object> copied = copiedRef.get();
+        if (copied == null || releaseTtlValueReferenceAfterCall && !copiedRef.compareAndSet(copied, null)) {
+            throw new IllegalStateException("TTL value reference is released after call!");
+        }
+
+        Map<TransmittableThreadLocal<?>, Object> backup = TransmittableThreadLocal.backupAndSetToCopied(copied);
+        try {
+            result = compute();
+            return true;
+        } finally {
+            TransmittableThreadLocal.restoreBackup(backup);
+        }
+    }
+
+}

--- a/src/test/java/com/alibaba/ttl/TtlRecursiveActionTest.java
+++ b/src/test/java/com/alibaba/ttl/TtlRecursiveActionTest.java
@@ -1,0 +1,194 @@
+package com.alibaba.ttl;
+
+import java.util.Random;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+
+import com.alibaba.ttl.testmodel.PrintAction;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static com.alibaba.ttl.Utils.PARENT_AFTER_CREATE_TTL_TASK;
+import static com.alibaba.ttl.Utils.PARENT_MODIFIED_IN_CHILD;
+import static com.alibaba.ttl.Utils.PARENT_UNMODIFIED_IN_CHILD;
+import static com.alibaba.ttl.Utils.assertTtlInstances;
+import static com.alibaba.ttl.Utils.copied;
+import static com.alibaba.ttl.Utils.createTestTtlValue;
+
+/**
+ * TtlRecursiveAction test class
+ *
+ * @author LNAmp
+ * @since 2.3.0
+ *
+ */
+public class TtlRecursiveActionTest {
+    private static ForkJoinPool pool = new ForkJoinPool();
+
+    private static ForkJoinPool singleThreadPool = new ForkJoinPool(1);
+
+    public static final String PARENT_TAG = "1";
+
+    public static final String CHILD_TAG = "11";
+
+    private static int[] arr;
+
+    private static int[] simpleArr;
+
+    private static Integer total = 0;
+
+    private static Integer simpleTotal = 0;
+
+    @BeforeClass
+    public static void beforeClass() {
+        arr = new int[1000];
+        Random rand = new Random();
+        for (int i = 0; i < arr.length; i++) {
+            int tmp = rand.nextInt(20);
+            total += (arr[i] = tmp);
+        }
+
+        simpleArr = new int[5];
+        for (int i = 0; i < simpleArr.length; i++) {
+            int tmp = rand.nextInt(20);
+            simpleTotal += (simpleArr[i] = tmp);
+        }
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        pool.shutdown();
+        singleThreadPool.shutdown();
+    }
+
+    @Test
+    public void test_TtlRecursiveTask_InSameThread_changeValue() throws Exception {
+        ConcurrentMap<String, TransmittableThreadLocal<String>> ttlInstances = createTestTtlValue();
+
+        PrintAction printAction = new PrintAction(simpleArr, 0, simpleArr.length, PARENT_TAG, ttlInstances, true);
+
+        TransmittableThreadLocal<String> after = new TransmittableThreadLocal<String>();
+        after.set(PARENT_AFTER_CREATE_TTL_TASK);
+        ttlInstances.put(PARENT_AFTER_CREATE_TTL_TASK, after);
+
+        printAction.exec();
+
+
+        // child Inheritable
+        assertTtlInstances(printAction.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD + PARENT_TAG, PARENT_MODIFIED_IN_CHILD
+        );
+
+        // child do not effect parent
+        assertTtlInstances(copied(ttlInstances),
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD, PARENT_MODIFIED_IN_CHILD, // restored after call!
+            PARENT_AFTER_CREATE_TTL_TASK, PARENT_AFTER_CREATE_TTL_TASK
+        );
+    }
+
+
+    @Test
+    public void test_TtlRecursiveTask_asyncWithForkJoinPool_notChangeValue() throws Exception {
+        ConcurrentMap<String, TransmittableThreadLocal<String>> ttlInstances = createTestTtlValue();
+
+        PrintAction printAction = new PrintAction(arr, 0, arr.length, PARENT_TAG, ttlInstances, false);
+
+        TransmittableThreadLocal<String> after = new TransmittableThreadLocal<String>();
+        after.set(PARENT_AFTER_CREATE_TTL_TASK);
+        ttlInstances.put(PARENT_AFTER_CREATE_TTL_TASK, after);
+
+        Future<Void> future = pool.submit(printAction);
+        future.get();
+
+        // child Inheritable
+        assertTtlInstances(printAction.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD, PARENT_MODIFIED_IN_CHILD
+        );
+
+        // grandchild Inheritable
+        assertTtlInstances(printAction.innerLeftPrintAction.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD, PARENT_MODIFIED_IN_CHILD
+        );
+
+        // child do not effect parent
+        assertTtlInstances(copied(ttlInstances),
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD, PARENT_MODIFIED_IN_CHILD,
+            PARENT_AFTER_CREATE_TTL_TASK, PARENT_AFTER_CREATE_TTL_TASK
+        );
+    }
+
+    @Test
+    public void test_TtlRecursiveTask_asyncWithForkJoinPool_changeValue() throws Exception {
+        ConcurrentMap<String, TransmittableThreadLocal<String>> ttlInstances = createTestTtlValue();
+
+        PrintAction printAction = new PrintAction(arr, 0, arr.length, PARENT_TAG, ttlInstances, true);
+
+        TransmittableThreadLocal<String> after = new TransmittableThreadLocal<String>();
+        after.set(PARENT_AFTER_CREATE_TTL_TASK);
+        ttlInstances.put(PARENT_AFTER_CREATE_TTL_TASK, after);
+
+        Future<Void> future = pool.submit(printAction);
+        future.get();
+
+        // child Inheritable
+        assertTtlInstances(printAction.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD + PARENT_TAG, PARENT_MODIFIED_IN_CHILD
+        );
+
+        // grand child Inheritable
+        assertTtlInstances(printAction.innerLeftPrintAction.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD + PARENT_TAG + CHILD_TAG, PARENT_MODIFIED_IN_CHILD
+        );
+
+        // child do not effect parent
+        assertTtlInstances(copied(ttlInstances),
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD, PARENT_MODIFIED_IN_CHILD,
+            PARENT_AFTER_CREATE_TTL_TASK, PARENT_AFTER_CREATE_TTL_TASK
+        );
+    }
+
+    @Test
+    public void test_TtlRecursiveTask_asyncWithSingleThreadForkJoinPool_changeValue() throws Exception {
+        ConcurrentMap<String, TransmittableThreadLocal<String>> ttlInstances = createTestTtlValue();
+
+        PrintAction printAction = new PrintAction(arr, 0, arr.length, PARENT_TAG, ttlInstances, true);
+
+        TransmittableThreadLocal<String> after = new TransmittableThreadLocal<String>();
+        after.set(PARENT_AFTER_CREATE_TTL_TASK);
+        ttlInstances.put(PARENT_AFTER_CREATE_TTL_TASK, after);
+
+        Future<Void> future = singleThreadPool.submit(printAction);
+        future.get();
+
+        // child Inheritable
+        assertTtlInstances(printAction.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD + PARENT_TAG, PARENT_MODIFIED_IN_CHILD
+        );
+
+        //  grandchild Inheritable
+        assertTtlInstances(printAction.innerLeftPrintAction.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD + PARENT_TAG + CHILD_TAG, PARENT_MODIFIED_IN_CHILD
+        );
+
+        // child do not effect parent
+        assertTtlInstances(copied(ttlInstances),
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD, PARENT_MODIFIED_IN_CHILD,
+            PARENT_AFTER_CREATE_TTL_TASK, PARENT_AFTER_CREATE_TTL_TASK
+        );
+    }
+
+}

--- a/src/test/java/com/alibaba/ttl/TtlRecursiveTaskTest.java
+++ b/src/test/java/com/alibaba/ttl/TtlRecursiveTaskTest.java
@@ -1,0 +1,200 @@
+package com.alibaba.ttl;
+
+import java.util.Random;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+
+import com.alibaba.ttl.testmodel.CalTask;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static com.alibaba.ttl.Utils.PARENT_AFTER_CREATE_TTL_TASK;
+import static com.alibaba.ttl.Utils.PARENT_MODIFIED_IN_CHILD;
+import static com.alibaba.ttl.Utils.PARENT_UNMODIFIED_IN_CHILD;
+import static com.alibaba.ttl.Utils.assertTtlInstances;
+import static com.alibaba.ttl.Utils.copied;
+import static com.alibaba.ttl.Utils.createTestTtlValue;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * TtlRecursiveTask test class
+ *
+ * @author LNAmp
+ * @since 2.3.0
+ */
+public class TtlRecursiveTaskTest {
+
+    private static ForkJoinPool pool = new ForkJoinPool();
+
+    private static ForkJoinPool singleThreadPool = new ForkJoinPool(1);
+
+    public static final String PARENT_TAG = "1";
+
+    public static final String CHILD_TAG = "11";
+
+    private static int[] arr;
+
+    private static int[] simpleArr;
+
+    private static Integer total = 0;
+
+    private static Integer simpleTotal = 0;
+
+    @BeforeClass
+    public static void beforeClass() {
+        arr = new int[1000];
+        Random rand = new Random();
+        for (int i = 0; i < arr.length; i++) {
+            int tmp = rand.nextInt(20);
+            total += (arr[i] = tmp);
+        }
+
+        simpleArr = new int[5];
+        for (int i = 0; i < simpleArr.length; i++) {
+            int tmp = rand.nextInt(20);
+            simpleTotal += (simpleArr[i] = tmp);
+        }
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        pool.shutdown();
+        singleThreadPool.shutdown();
+    }
+
+    @Test
+    public void test_TtlRecursiveTask_InSameThread_changeValue() throws Exception {
+        ConcurrentMap<String, TransmittableThreadLocal<String>> ttlInstances = createTestTtlValue();
+
+        CalTask calTask = new CalTask(simpleArr, 0, simpleArr.length, PARENT_TAG, ttlInstances, true);
+
+        TransmittableThreadLocal<String> after = new TransmittableThreadLocal<String>();
+        after.set(PARENT_AFTER_CREATE_TTL_TASK);
+        ttlInstances.put(PARENT_AFTER_CREATE_TTL_TASK, after);
+
+        calTask.exec();
+
+        assertEquals(simpleTotal, calTask.getRawResult());
+
+        // child Inheritable
+        assertTtlInstances(calTask.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD + PARENT_TAG, PARENT_MODIFIED_IN_CHILD
+        );
+
+        // child do not effect parent
+        assertTtlInstances(copied(ttlInstances),
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD, PARENT_MODIFIED_IN_CHILD, // restored after call!
+            PARENT_AFTER_CREATE_TTL_TASK, PARENT_AFTER_CREATE_TTL_TASK
+        );
+    }
+
+
+    @Test
+    public void test_TtlRecursiveTask_asyncWithForkJoinPool_notChangeValue() throws Exception {
+        ConcurrentMap<String, TransmittableThreadLocal<String>> ttlInstances = createTestTtlValue();
+
+        CalTask calTask = new CalTask(arr, 0, arr.length, PARENT_TAG, ttlInstances, false);
+
+        TransmittableThreadLocal<String> after = new TransmittableThreadLocal<String>();
+        after.set(PARENT_AFTER_CREATE_TTL_TASK);
+        ttlInstances.put(PARENT_AFTER_CREATE_TTL_TASK, after);
+
+        Future<Integer> future = pool.submit(calTask);
+
+        Assert.assertEquals(total, future.get());
+
+        // child Inheritable
+        assertTtlInstances(calTask.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD, PARENT_MODIFIED_IN_CHILD
+        );
+
+        // grandchild Inheritable
+        assertTtlInstances(calTask.innerLeftCalTask.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD, PARENT_MODIFIED_IN_CHILD
+        );
+
+        // child do not effect parent
+        assertTtlInstances(copied(ttlInstances),
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD, PARENT_MODIFIED_IN_CHILD,
+            PARENT_AFTER_CREATE_TTL_TASK, PARENT_AFTER_CREATE_TTL_TASK
+        );
+    }
+
+    @Test
+    public void test_TtlRecursiveTask_asyncWithForkJoinPool_changeValue() throws Exception {
+        ConcurrentMap<String, TransmittableThreadLocal<String>> ttlInstances = createTestTtlValue();
+
+        CalTask calTask = new CalTask(arr, 0, arr.length, PARENT_TAG, ttlInstances, true);
+
+        TransmittableThreadLocal<String> after = new TransmittableThreadLocal<String>();
+        after.set(PARENT_AFTER_CREATE_TTL_TASK);
+        ttlInstances.put(PARENT_AFTER_CREATE_TTL_TASK, after);
+
+        Future<Integer> future = pool.submit(calTask);
+
+        Assert.assertEquals(total, future.get());
+
+        // child Inheritable
+        assertTtlInstances(calTask.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD + PARENT_TAG, PARENT_MODIFIED_IN_CHILD
+        );
+
+        // grand child Inheritable
+        assertTtlInstances(calTask.innerLeftCalTask.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD + PARENT_TAG + CHILD_TAG, PARENT_MODIFIED_IN_CHILD
+        );
+
+        // child do not effect parent
+        assertTtlInstances(copied(ttlInstances),
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD, PARENT_MODIFIED_IN_CHILD,
+            PARENT_AFTER_CREATE_TTL_TASK, PARENT_AFTER_CREATE_TTL_TASK
+        );
+    }
+
+    @Test
+    public void test_TtlRecursiveTask_asyncWithSingleThreadForkJoinPool_changeValue() throws Exception {
+        ConcurrentMap<String, TransmittableThreadLocal<String>> ttlInstances = createTestTtlValue();
+
+        CalTask calTask = new CalTask(arr, 0, arr.length, PARENT_TAG, ttlInstances, true);
+
+        TransmittableThreadLocal<String> after = new TransmittableThreadLocal<String>();
+        after.set(PARENT_AFTER_CREATE_TTL_TASK);
+        ttlInstances.put(PARENT_AFTER_CREATE_TTL_TASK, after);
+
+        Future<Integer> future = singleThreadPool.submit(calTask);
+
+        Assert.assertEquals(total, future.get());
+
+        // child Inheritable
+        assertTtlInstances(calTask.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD + PARENT_TAG, PARENT_MODIFIED_IN_CHILD
+        );
+
+        // grandchild Inheritable
+        assertTtlInstances(calTask.innerLeftCalTask.copied,
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD + PARENT_TAG + CHILD_TAG, PARENT_MODIFIED_IN_CHILD
+        );
+
+        // child do not effect parent
+        assertTtlInstances(copied(ttlInstances),
+            PARENT_UNMODIFIED_IN_CHILD, PARENT_UNMODIFIED_IN_CHILD,
+            PARENT_MODIFIED_IN_CHILD, PARENT_MODIFIED_IN_CHILD,
+            PARENT_AFTER_CREATE_TTL_TASK, PARENT_AFTER_CREATE_TTL_TASK
+        );
+    }
+
+}

--- a/src/test/java/com/alibaba/ttl/Utils.java
+++ b/src/test/java/com/alibaba/ttl/Utils.java
@@ -65,6 +65,21 @@ public final class Utils {
         return Utils.copied(ttlInstances);
     }
 
+    public static Map<String, Object> modifyValuesExistInTtlInstances(String tag, ConcurrentMap<String, TransmittableThreadLocal<String>> ttlInstances) {
+        System.out.println(tag + " Before Run:");
+        Utils.print(ttlInstances);
+        System.out.println();
+
+        // 1. modify the parent key
+        String p = ttlInstances.get(PARENT_MODIFIED_IN_CHILD).get() + tag;
+        ttlInstances.get(PARENT_MODIFIED_IN_CHILD).set(p);
+
+        // store value in task
+        System.out.println(tag + " After Run:");
+        Utils.print(ttlInstances);
+
+        return Utils.copied(ttlInstances);
+    }
     public static <T> void print(ConcurrentMap<String, TransmittableThreadLocal<T>> ttlInstances) {
         for (Map.Entry<String, TransmittableThreadLocal<T>> entry : ttlInstances.entrySet()) {
             String key = entry.getKey();

--- a/src/test/java/com/alibaba/ttl/testmodel/CalTask.java
+++ b/src/test/java/com/alibaba/ttl/testmodel/CalTask.java
@@ -1,0 +1,72 @@
+package com.alibaba.ttl.testmodel;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+import com.alibaba.ttl.TransmittableThreadLocal;
+import com.alibaba.ttl.TtlRecursiveTask;
+import com.alibaba.ttl.TtlRecursiveTaskTest;
+import com.alibaba.ttl.Utils;
+
+/**
+ * A test demo class
+ *
+ * @see com.alibaba.ttl.TtlRecursiveTask
+ * @author LNAmp
+ * @since 2.3.0
+ */
+public class CalTask extends TtlRecursiveTask<Integer> {
+
+    private final int[] toCal;
+    private final int start;
+    private final int end;
+
+    private final String tag;
+
+    private final boolean changeTtlValue;
+
+    public volatile Map<String, Object> copied;
+
+    public volatile CalTask innerLeftCalTask;
+
+    private final ConcurrentMap<String, TransmittableThreadLocal<String>> ttlMap;
+
+    public CalTask(int[] toCal, int start, int end, String tag, ConcurrentMap<String, TransmittableThreadLocal<String>> ttlMap,
+                   boolean changeTtlValue) {
+        super();
+        this.tag = tag;
+        this.changeTtlValue = changeTtlValue;
+        this.ttlMap = ttlMap;
+        this.toCal = toCal;
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    protected Integer compute() {
+        if (changeTtlValue) {
+            Utils.modifyValuesExistInTtlInstances(tag, ttlMap);
+        }
+
+        try {
+            int sum = 0;
+            if (end - start < 5) {
+                for (int i = start; i < end; i++) {
+                    sum += toCal[i];
+                }
+                return sum;
+
+            } else {
+                int mid = (start + end) / 2;
+                CalTask left = new CalTask(toCal, start, mid, TtlRecursiveTaskTest.CHILD_TAG, ttlMap, changeTtlValue);
+                CalTask right = new CalTask(toCal, mid, end, TtlRecursiveTaskTest.CHILD_TAG, ttlMap, false);
+                innerLeftCalTask = left;
+                left.fork();
+                right.fork();
+                return left.join() + right.join();
+            }
+        } finally {
+            this.copied = Utils.copied(this.ttlMap);
+        }
+    }
+}

--- a/src/test/java/com/alibaba/ttl/testmodel/PrintAction.java
+++ b/src/test/java/com/alibaba/ttl/testmodel/PrintAction.java
@@ -1,0 +1,70 @@
+package com.alibaba.ttl.testmodel;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+import com.alibaba.ttl.TransmittableThreadLocal;
+import com.alibaba.ttl.TtlRecursiveAction;
+import com.alibaba.ttl.TtlRecursiveTaskTest;
+import com.alibaba.ttl.Utils;
+
+/**
+ * A test demo class
+ *
+ * @see com.alibaba.ttl.TtlRecursiveAction
+ * @author LNAmp
+ * @since 2.3.0
+ */
+public class PrintAction extends TtlRecursiveAction {
+    private final int[] toCal;
+    private final int start;
+    private final int end;
+
+    private final String tag;
+
+    private final boolean changeTtlValue;
+
+    public volatile Map<String, Object> copied;
+
+    public volatile PrintAction innerLeftPrintAction;
+
+    private final ConcurrentMap<String, TransmittableThreadLocal<String>> ttlMap;
+
+    public PrintAction(int[] toCal, int start, int end, String tag, ConcurrentMap<String, TransmittableThreadLocal<String>> ttlMap,
+                   boolean changeTtlValue) {
+        super();
+        this.tag = tag;
+        this.changeTtlValue = changeTtlValue;
+        this.ttlMap = ttlMap;
+        this.toCal = toCal;
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    protected void compute() {
+        if (changeTtlValue) {
+            Utils.modifyValuesExistInTtlInstances(tag, ttlMap);
+        }
+
+        try {
+            if (end - start < 5) {
+                for (int i = start; i < end; i++) {
+                    System.out.println("num: " + toCal[i]);
+                }
+
+            } else {
+                int mid = (start + end) / 2;
+                PrintAction left = new PrintAction(toCal, start, mid, TtlRecursiveTaskTest.CHILD_TAG, ttlMap, changeTtlValue);
+                PrintAction right = new PrintAction(toCal, mid, end, TtlRecursiveTaskTest.CHILD_TAG, ttlMap, false);
+                innerLeftPrintAction = left;
+                left.fork();
+                right.fork();
+                left.join();
+                right.join();
+            }
+        } finally {
+            this.copied = Utils.copied(this.ttlMap);
+        }
+    }
+}


### PR DESCRIPTION
使用TTL增强了最常用的两种ForkJoinTask(RecursiveAction/RecursiveTask)
我看@wuwen5把代码pr到 support-fork-join-pool#76 分支了，我也向这个分支提个pr吧。
