### PR TITLE
use entrySet instead of keySet

### DIFF
--- a/src/main/java/com/alibaba/ttl/TransmittableThreadLocal.java
+++ b/src/main/java/com/alibaba/ttl/TransmittableThreadLocal.java
@@ -116,7 +116,9 @@ public class TransmittableThreadLocal<T> extends InheritableThreadLocal<T> {
 
     static Map<TransmittableThreadLocal<?>, Object> copy() {
         Map<TransmittableThreadLocal<?>, Object> copy = new HashMap<>();
-        for (TransmittableThreadLocal<?> threadLocal : holder.get().keySet()) {
+        for (Map.Entry<TransmittableThreadLocal<?>, ?> entry : holder.get().entrySet()) {
+            TransmittableThreadLocal<?> threadLocal = entry.getKey();
+
             copy.put(threadLocal, threadLocal.copyValue());
         }
         return copy;


### PR DESCRIPTION
https://github.com/alibaba/p3c/blob/master/p3c-gitbook/%E7%BC%96%E7%A8%8B%E8%A7%84%E7%BA%A6/%E9%9B%86%E5%90%88%E5%A4%84%E7%90%86.md
10.【推荐】使用entrySet遍历Map类集合KV，而不是keySet方式进行遍历。

keySet遍历2次，一次是转为Iterator对象，另一次是从hashMap中取出key所对应的value;
而entrySet只是遍历了一次就把key和value都放到了entry中，效率更高。
如果是JDK8，推荐使用Map.foreach方法