### PR TITLE
Support FastThreadLocal mode. Resolves #94

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,13 @@
 			<version>3.23.1-GA</version>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-all</artifactId>
+			<version>4.0.20.Final</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
 		<!-- Testing frameworks and related dependencies -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom4ide.xml
+++ b/pom4ide.xml
@@ -95,6 +95,13 @@
 			<version>3.23.1-GA</version>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-all</artifactId>
+			<version>4.0.20.Final</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
 		<!-- Testing frameworks and related dependencies -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/com/alibaba/ttl/internal/FastThreadLocalValue.java
+++ b/src/main/java/com/alibaba/ttl/internal/FastThreadLocalValue.java
@@ -1,0 +1,29 @@
+package com.alibaba.ttl.internal;
+
+import io.netty.util.internal.FastThreadLocal;
+
+/**
+ * {@link FastThreadLocal} implementation for {@link com.alibaba.ttl.TransmittableThreadLocal} value holder
+ *
+ * @author Yang Fang (snoop dot fy at gmail dot com)
+ * @since 2.7.0
+ */
+public class FastThreadLocalValue<T> implements TtlValue<T> {
+
+    private FastThreadLocal<T> holder = new FastThreadLocal<T>();
+
+    @Override
+    public T get() {
+        return holder.get();
+    }
+
+    @Override
+    public void set(T t) {
+        holder.set(t);
+    }
+
+    @Override
+    public void remove() {
+        holder.remove();
+    }
+}

--- a/src/main/java/com/alibaba/ttl/internal/TtlValue.java
+++ b/src/main/java/com/alibaba/ttl/internal/TtlValue.java
@@ -1,0 +1,17 @@
+package com.alibaba.ttl.internal;
+
+/**
+ * Hold {@link com.alibaba.ttl.TransmittableThreadLocal} value, can be implemented in varied ways depending on the runtime.
+ *
+ * @author Yang Fang (snoop dot fy at gmail dot com)
+ * @since 2.7.0
+ */
+public interface TtlValue<T> {
+
+    T get();
+
+    void set(T t);
+
+    void remove();
+
+}

--- a/src/main/java/com/alibaba/ttl/internal/TtlValueFactory.java
+++ b/src/main/java/com/alibaba/ttl/internal/TtlValueFactory.java
@@ -1,0 +1,49 @@
+package com.alibaba.ttl.internal;
+
+/**
+ * {@link com.alibaba.ttl.TransmittableThreadLocal} value holder factory.
+ *
+ * <p>
+ * If there is netty in the runtime and
+ * {@link io.netty.util.internal.FastThreadLocal} is supported. You can just set
+ *
+ * <pre>-Dttl.fastthreadlocal.enable=true</pre>
+ *
+ * to enable FastThreadLocal mode for better performance.
+ * </p>
+ *
+ * <p>
+ * Caution: If FastThreadLocal mode is enabled, {@link com.alibaba.ttl.TransmittableThreadLocal}
+ * will NEVER be inheritable!
+ * </p>
+ *
+ * @author Yang Fang (snoop dot fy at gmail dot com)
+ * @since 2.7.0
+ */
+public class TtlValueFactory {
+
+    private static final String FAST_THREAD_LOCAL_ENABLE = "ttl.fastthreadlocal.enable";
+
+    private static final boolean IS_FAST_THREAD_LOCAL_SUPPORT = isClassPresent("io.netty.util.internal.FastThreadLocal");
+
+    public static <T> TtlValue<T> create() {
+        if (isFastThreadLocalEnabled() && IS_FAST_THREAD_LOCAL_SUPPORT) {
+            return new FastThreadLocalValue<T>();
+        } else {
+            return null;
+        }
+    }
+
+    public static boolean isFastThreadLocalEnabled() {
+        return Boolean.parseBoolean(System.getProperty(FAST_THREAD_LOCAL_ENABLE, "false"));
+    }
+
+    private static boolean isClassPresent(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/com/alibaba/ttl/TtlCallableTest.kt
+++ b/src/test/java/com/alibaba/ttl/TtlCallableTest.kt
@@ -1,6 +1,7 @@
 package com.alibaba.ttl
 
 import com.alibaba.*
+import com.alibaba.ttl.internal.TtlValueFactory
 import com.alibaba.ttl.testmodel.Call
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.instanceOf
@@ -33,12 +34,14 @@ class TtlCallableTest {
         val ret = ttlCallable.call()
         assertEquals("ok", ret)
 
+        // inheritable is not supported by FastThreadLocal mode
+        if (!TtlValueFactory.isFastThreadLocalEnabled()) {
+            // child Inheritable
+            assertChildTtlValues("1", call.copied)
 
-        // child Inheritable
-        assertChildTtlValues("1", call.copied)
-
-        // child do not effect parent
-        assertParentTtlValues(copyTtlValues(ttlInstances))
+            // child do not effect parent
+            assertParentTtlValues(copyTtlValues(ttlInstances))
+        }
     }
 
     @Test

--- a/src/test/java/com/alibaba/ttl/TtlRunnableTest.kt
+++ b/src/test/java/com/alibaba/ttl/TtlRunnableTest.kt
@@ -1,6 +1,7 @@
 package com.alibaba.ttl
 
 import com.alibaba.*
+import com.alibaba.ttl.internal.TtlValueFactory
 import com.alibaba.ttl.testmodel.*
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.instanceOf
@@ -33,11 +34,14 @@ class TtlRunnableTest {
         ttlRunnable.run()
 
 
-        // child Inheritable
-        assertChildTtlValues("1", task.copied)
+        // inheritable is not supported by FastThreadLocal mode
+        if (!TtlValueFactory.isFastThreadLocalEnabled()) {
+            // child Inheritable
+            assertChildTtlValues("1", task.copied)
 
-        // child do not effect parent
-        assertParentTtlValues(copyTtlValues(ttlInstances))
+            // child do not effect parent
+            assertParentTtlValues(copyTtlValues(ttlInstances))
+        }
     }
 
     @Test
@@ -55,8 +59,11 @@ class TtlRunnableTest {
         thread1.join()
 
 
-        // child Inheritable
-        assertChildTtlValues("1", task.copied)
+        // inheritable is not supported by FastThreadLocal mode
+        if (!TtlValueFactory.isFastThreadLocalEnabled()) {
+            // child Inheritable
+            assertChildTtlValues("1", task.copied)
+        }
 
         // child do not effect parent
         assertParentTtlValues(copyTtlValues(ttlInstances))
@@ -77,8 +84,11 @@ class TtlRunnableTest {
         submit.get()
 
 
-        // child Inheritable
-        assertChildTtlValues("1", task.copied)
+        // inheritable is not supported by FastThreadLocal mode
+        if (!TtlValueFactory.isFastThreadLocalEnabled()) {
+            // child Inheritable
+            assertChildTtlValues("1", task.copied)
+        }
 
         // child do not effect parent
         assertParentTtlValues(copyTtlValues(ttlInstances))
@@ -102,8 +112,11 @@ class TtlRunnableTest {
         submit.get()
 
 
-        // child Inheritable
-        assertChildTtlValues("1", task.copied)
+        // inheritable is not supported by FastThreadLocal mode
+        if (!TtlValueFactory.isFastThreadLocalEnabled()) {
+            // child Inheritable
+            assertChildTtlValues("1", task.copied)
+        }
 
         // child do not effect parent
         assertParentTtlValues(copyTtlValues(ttlInstances))
@@ -168,11 +181,14 @@ class TtlRunnableTest {
         val submit = executorService.submit(ttlRunnable)
         submit.get()
 
-        // child Inheritable
-        assertEquals(3, task.copied.size.toLong())
-        assertEquals(FooPojo(PARENT_CREATE_UNMODIFIED_IN_CHILD, 1), task.copied[PARENT_CREATE_UNMODIFIED_IN_CHILD])
-        assertEquals(FooPojo(PARENT_CREATE_MODIFIED_IN_CHILD + "1", 2), task.copied[PARENT_CREATE_MODIFIED_IN_CHILD])
-        assertEquals(FooPojo(CHILD_CREATE + 1, 3), task.copied[CHILD_CREATE + 1])
+        // inheritable is not supported by FastThreadLocal mode
+        if (!TtlValueFactory.isFastThreadLocalEnabled()) {
+            // child Inheritable
+            assertEquals(3, task.copied.size.toLong())
+            assertEquals(FooPojo(PARENT_CREATE_UNMODIFIED_IN_CHILD, 1), task.copied[PARENT_CREATE_UNMODIFIED_IN_CHILD])
+            assertEquals(FooPojo(PARENT_CREATE_MODIFIED_IN_CHILD + "1", 2), task.copied[PARENT_CREATE_MODIFIED_IN_CHILD])
+            assertEquals(FooPojo(CHILD_CREATE + 1, 3), task.copied[CHILD_CREATE + 1])
+        }
 
         // child do not effect parent
         val copied = copyTtlValues(ttlInstances)


### PR DESCRIPTION
1. Support FastThreadLocal mode when run with netty by config
   -Dttl.fastthreadlocal.enable=true, default is false
2. Caution: when FastThreadLocal mode is enabled,
   TransmittableThreadLocal can NEVER be inheritable.
3. Disable the tests which depends on the ability of InheritableThreadLocal
   when FastThreadLocal is enabled.