### PR TITLE
+ support disable inheritable feature

### DIFF
--- a/src/test/java/com/alibaba/Utils.kt
+++ b/src/test/java/com/alibaba/Utils.kt
@@ -141,6 +141,16 @@ fun <T> assertChildTtlValues(tag: String, values: TtlValues<T>) {
     )
 }
 
+fun <T> assertChildTtlValuesDisableInheritable(tag: String, values: TtlValues<T>) {
+    // if Inheritable is disabled,  PARENT_CREATE_UNMODIFIED_IN_CHILD will not be seen
+    // and PARENT_CREATE_MODIFIED_IN_CHILD will be modified on null value.
+    assertTtlValues(
+            mapOf(PARENT_CREATE_MODIFIED_IN_CHILD to "null$tag",
+                    CHILD_CREATE + tag to CHILD_CREATE + tag),
+            values
+    )
+}
+
 fun <T> assertChildTtlValuesWithParentCreateAfterCreateChild(tag: String, values: TtlValues<T>) {
     assertTtlValues(
             mapOf(PARENT_CREATE_MODIFIED_IN_CHILD to PARENT_CREATE_MODIFIED_IN_CHILD + tag,

--- a/src/test/java/com/alibaba/ttl/TtlRunnableTest.kt
+++ b/src/test/java/com/alibaba/ttl/TtlRunnableTest.kt
@@ -61,7 +61,11 @@ class TtlRunnableTest {
 
 
         // child Inheritable
-        assertChildTtlValues("1", task.copied)
+        if (TransmittableThreadLocal.isInheritable()) {
+            assertChildTtlValues("1", task.copied)
+        } else {
+            assertChildTtlValuesDisableInheritable("1", task.copied)
+        }
 
         // child do not effect parent
         assertParentTtlValues(copyTtlValues(ttlInstances))

--- a/src/test/java/com/alibaba/ttl/reported_bugs/Bug70_Test.kt
+++ b/src/test/java/com/alibaba/ttl/reported_bugs/Bug70_Test.kt
@@ -17,6 +17,11 @@ class Bug70_Test {
 
     @Test
     fun test_bug70() {
+        // only works if TransmittableThreadLocal is inheritable
+        if (!TransmittableThreadLocal.isInheritable()) {
+            return
+        }
+
         val hello = "hello"
         val executorService = Executors.newSingleThreadExecutor()
         val threadLocal = TransmittableThreadLocal<String>().apply { set(hello) }


### PR DESCRIPTION
Inheritable feature by using InheritableThreadLocal can be disabled by
setting `com.alibaba.ttl.inheritable` to false to avoid potential
leaking problem described in #100, default value is true to ensure
compatible with previous versions.