### PR TITLE
 + support optional inheritable feature

### DIFF
--- a/src/main/java/com/alibaba/ttl/NoInheritableTTL.java
+++ b/src/main/java/com/alibaba/ttl/NoInheritableTTL.java
@@ -1,0 +1,15 @@
+package com.alibaba.ttl;
+
+/**
+ * Disable inheritable feature by {@link InheritableThreadLocal} to prevent potential leaking problem.
+ *
+ * @author Yang Fang (snoop dot fy at gmail dot com)
+ * @since 2.2.2
+ */
+public class NoInheritableTTL<T> extends TransmittableThreadLocal<T> {
+
+    @Override
+    protected T childValue(T parentValue) {
+        return null;
+    }
+}

--- a/src/main/java/com/alibaba/ttl/TransmittableThreadLocal.java
+++ b/src/main/java/com/alibaba/ttl/TransmittableThreadLocal.java
@@ -17,6 +17,8 @@ import java.util.logging.Logger;
  * Note: {@link TransmittableThreadLocal} extends {@link java.lang.InheritableThreadLocal},
  * so {@link TransmittableThreadLocal} first is a {@link java.lang.InheritableThreadLocal}.
  *
+ * Caution: Potential leaking problem maybe introduced by {@link InheritableThreadLocal}, you can use {@link NoInheritableTTL} instead.
+ *
  * @author Jerry Lee (oldratlee at gmail dot com)
  * @see TtlRunnable
  * @see TtlCallable

--- a/src/test/java/com/alibaba/ttl/NoInheritableTTLTest.kt
+++ b/src/test/java/com/alibaba/ttl/NoInheritableTTLTest.kt
@@ -1,0 +1,34 @@
+package com.alibaba.ttl
+
+import com.alibaba.*
+import com.alibaba.ttl.testmodel.Task
+import org.junit.Test
+
+/**
+ * @author Yang Fang (snoop dot fy at gmail dot com)
+ */
+class NoInheritableTTLTest {
+
+    @Test
+    fun test_noInheritable_asyncRunByNewThread() {
+        val ttlInstances = createParentTtlInstances(noInherit = true)
+
+        val task = Task("1", ttlInstances)
+        val thread1 = Thread(task)
+
+        // create after new Task, won't see parent value in in task!
+        createParentTtlInstancesAfterCreateChild(ttlInstances)
+
+
+        thread1.start()
+        thread1.join()
+
+
+        // child Inheritable
+        assertChildTtlValuesWithParentCreateAfterCreateChild("1", task.copied, noInherit = true)
+
+        // child do not effect parent
+        assertParentTtlValues(copyTtlValues(ttlInstances))
+    }
+
+}


### PR DESCRIPTION
    Inheritable feature by using InheritableThreadLocal can be disabled by
    overriding `childValue` and `return null` to avoid potential
    leaking problem described in #100. Implementation is provided as
    NoInheritableTTL.