### PR TITLE
support thread local integration #130

### DIFF
--- a/src/main/java/com/alibaba/ttl/TransmittableThreadLocal.java
+++ b/src/main/java/com/alibaba/ttl/TransmittableThreadLocal.java
@@ -63,6 +63,9 @@ public class TransmittableThreadLocal<T> extends InheritableThreadLocal<T> {
      * This method merely returns reference of its source thread value, and should be overridden
      * if a different behavior is desired.
      *
+     * @param parentValue parent value to be compute
+     * @return computed value
+     *
      * @since 1.0.0
      */
     protected T copy(T parentValue) {
@@ -126,12 +129,13 @@ public class TransmittableThreadLocal<T> extends InheritableThreadLocal<T> {
     }
 
     /**
-     * Register a ThreadLocal to be transmitted.
+     * Register a ThreadLocal to be transmittable.<br/>
+     * Undo by {@link TransmittableThreadLocal#untransmit(ThreadLocal)}
      *
      * @param threadLocal ThreadLocal need to be transmitted.
      * @return false if already been registered.
      */
-    public static boolean register(ThreadLocal threadLocal) {
+    public static boolean transmit(ThreadLocal threadLocal) {
         if (holder.get().containsKey(threadLocal)) {
             return false;
         } else {
@@ -141,12 +145,12 @@ public class TransmittableThreadLocal<T> extends InheritableThreadLocal<T> {
     }
 
     /**
-     * Unregister ThreadLocal which will not be transmitted.
+     * Unregister ThreadLocal which will not be transmittable.
      *
      * @param threadLocal ThreadLocal not need to be transmitted.
      * @return false if not registered or already been unregistered.
      */
-    public static boolean unregister(ThreadLocal threadLocal) {
+    public static boolean untransmit(ThreadLocal threadLocal) {
         if (holder.get().containsKey(threadLocal)) {
             holder.get().remove(threadLocal);
             return true;
@@ -208,7 +212,7 @@ public class TransmittableThreadLocal<T> extends InheritableThreadLocal<T> {
         } else {
             threadLocal.set(value);
             if (null == value) threadLocalRemove(threadLocal);
-            else register(threadLocal);
+            else transmit(threadLocal);
         }
     }
 

--- a/src/main/java/com/alibaba/ttl/TransmittableThreadLocal.java
+++ b/src/main/java/com/alibaba/ttl/TransmittableThreadLocal.java
@@ -129,7 +129,8 @@ public class TransmittableThreadLocal<T> extends InheritableThreadLocal<T> {
     }
 
     /**
-     * Register a ThreadLocal to be transmittable.<br/>
+     * Register a ThreadLocal to be transmittable.
+     * <p>
      * Undo by {@link TransmittableThreadLocal#untransmit(ThreadLocal)}
      *
      * @param threadLocal ThreadLocal need to be transmitted.

--- a/src/main/java/com/alibaba/ttl/TtlCallable.java
+++ b/src/main/java/com/alibaba/ttl/TtlCallable.java
@@ -102,6 +102,7 @@ public final class TtlCallable<V> implements Callable<V>, TtlEnhanced {
      *
      * @param callable                          input {@link Callable}
      * @param releaseTtlValueReferenceAfterCall release TTL value reference after run, avoid memory leak even if {@link TtlRunnable} is referred.
+     * @param <T>                               return type of Callable
      * @return Wrapped {@link Callable}
      */
     @Nullable
@@ -117,6 +118,7 @@ public final class TtlCallable<V> implements Callable<V>, TtlEnhanced {
      * @param callable                          input {@link Callable}
      * @param releaseTtlValueReferenceAfterCall release TTL value reference after run, avoid memory leak even if {@link TtlRunnable} is referred.
      * @param idempotent                        is idempotent or not. {@code true} will cover up bugs! <b>DO NOT</b> set, only when you know why.
+     * @param <T>                               return type of Callable
      * @return Wrapped {@link Callable}
      */
     @Nullable
@@ -135,6 +137,7 @@ public final class TtlCallable<V> implements Callable<V>, TtlEnhanced {
      * wrap input {@link Callable} Collection to {@link TtlCallable} Collection.
      *
      * @param tasks task to be wrapped
+     * @param <T>   return type of Callable
      * @return Wrapped {@link Callable}
      */
     @Nonnull
@@ -147,6 +150,7 @@ public final class TtlCallable<V> implements Callable<V>, TtlEnhanced {
      *
      * @param tasks                             task to be wrapped
      * @param releaseTtlValueReferenceAfterCall release TTL value reference after run, avoid memory leak even if {@link TtlRunnable} is referred.
+     * @param <T>                               return type of Callable
      * @return Wrapped {@link Callable}
      */
     @Nonnull
@@ -160,6 +164,7 @@ public final class TtlCallable<V> implements Callable<V>, TtlEnhanced {
      * @param tasks                             task to be wrapped
      * @param releaseTtlValueReferenceAfterCall release TTL value reference after run, avoid memory leak even if {@link TtlRunnable} is referred.
      * @param idempotent                        is idempotent or not. {@code true} will cover up bugs! <b>DO NOT</b> set, only when you know why.
+     * @param <T>                               return type of Callable
      * @return Wrapped {@link Callable}
      */
     @Nonnull
@@ -181,6 +186,9 @@ public final class TtlCallable<V> implements Callable<V>, TtlEnhanced {
      * <p>
      * so {@code TtlCallable.unwrap(TtlCallable.get(callable))} will always return the same input {@code callable} object.
      *
+     * @param callable  decorated Callable
+     * @param <T>       return type of Callable
+     * @return origin Callable
      * @see #get(Callable)
      * @since 2.10.2
      */
@@ -197,6 +205,9 @@ public final class TtlCallable<V> implements Callable<V>, TtlEnhanced {
      * <p>
      * This method is {@code null}-safe, when input {@code Callable} parameter is {@code null}, return a empty list.
      *
+     * @param tasks decorated Callables collection
+     * @param <T>   return type of Callable
+     * @return original Callable list
      * @see #gets(Collection)
      * @see #unwrap(Callable)
      * @since 2.10.2

--- a/src/main/java/com/alibaba/ttl/TtlRunnable.java
+++ b/src/main/java/com/alibaba/ttl/TtlRunnable.java
@@ -55,7 +55,7 @@ public final class TtlRunnable implements Runnable, TtlEnhanced {
     }
 
     /**
-     * return original/unwrapped {@link Runnable}.
+     * @return original/unwrapped {@link Runnable}.
      */
     @Nonnull
     public Runnable getRunnable() {
@@ -185,6 +185,9 @@ public final class TtlRunnable implements Runnable, TtlEnhanced {
      * <p>
      * so {@code TtlRunnable.unwrap(TtlRunnable.get(runnable))} will always return the same input {@code runnable} object.
      *
+     * @param runnable decorated runnable
+     * @return original runnable
+     *
      * @see #get(Runnable)
      * @since 2.10.2
      */
@@ -200,6 +203,9 @@ public final class TtlRunnable implements Runnable, TtlEnhanced {
      * Invoke {@link #unwrap(Runnable)} for each element in input collection.
      * <p>
      * This method is {@code null}-safe, when input {@code Runnable} parameter is {@code null}, return a empty list.
+     *
+     * @param tasks decorated runnable collection
+     * @return original runnable list
      *
      * @see #gets(Collection)
      * @see #unwrap(Runnable)

--- a/src/main/java/com/alibaba/ttl/TtlTimerTask.java
+++ b/src/main/java/com/alibaba/ttl/TtlTimerTask.java
@@ -135,6 +135,9 @@ public final class TtlTimerTask extends TimerTask implements TtlEnhanced {
      * this method is {@code null}-safe, when input {@code TimerTask} parameter is {@code null}, return {@code null};
      * if input {@code TimerTask} parameter is not a {@link TtlTimerTask} just return input {@code TimerTask}.
      *
+     * @param timerTask decorated timerTask
+     * @return original timerTask
+     *
      * @see #get(TimerTask)
      * @since 2.10.2
      */
@@ -150,6 +153,9 @@ public final class TtlTimerTask extends TimerTask implements TtlEnhanced {
      * Invoke {@link #unwrap(TimerTask)} for each element in input collection.
      * <p>
      * This method is {@code null}-safe, when input {@code TimerTask} parameter is {@code null}, return a empty list.
+     *
+     * @param tasks decorated timerTask collection
+     * @return original timerTask list
      *
      * @see #unwrap(TimerTask)
      * @since 2.10.2

--- a/src/main/java/com/alibaba/ttl/threadpool/DisableInheritableThreadFactory.java
+++ b/src/main/java/com/alibaba/ttl/threadpool/DisableInheritableThreadFactory.java
@@ -13,6 +13,8 @@ import java.util.concurrent.ThreadFactory;
 public interface DisableInheritableThreadFactory extends ThreadFactory {
     /**
      * Unwrap {@link DisableInheritableThreadFactory} to the original/underneath one.
+     *
+     * @return original ThreadFactory
      */
     @Nonnull
     ThreadFactory unwrap();

--- a/src/main/java/com/alibaba/ttl/threadpool/TtlExecutors.java
+++ b/src/main/java/com/alibaba/ttl/threadpool/TtlExecutors.java
@@ -34,6 +34,9 @@ public final class TtlExecutors {
      * {@link TransmittableThreadLocal} Wrapper of {@link Executor},
      * transmit the {@link TransmittableThreadLocal} from the task submit time of {@link Runnable}
      * to the execution time of {@link Runnable}.
+     *
+     * @param executor target {@link Executor} to be decorated.
+     * @return decorated {@link Executor}
      */
     @Nullable
     public static Executor getTtlExecutor(@Nullable Executor executor) {
@@ -47,6 +50,9 @@ public final class TtlExecutors {
      * {@link TransmittableThreadLocal} Wrapper of {@link ExecutorService},
      * transmit the {@link TransmittableThreadLocal} from the task submit time of {@link Runnable} or {@link java.util.concurrent.Callable}
      * to the execution time of {@link Runnable} or {@link java.util.concurrent.Callable}.
+     *
+     * @param executorService {@link ExecutorService} to be decorated
+     * @return decorated {@link ExecutorService}
      */
     @Nullable
     public static ExecutorService getTtlExecutorService(@Nullable ExecutorService executorService) {
@@ -60,6 +66,9 @@ public final class TtlExecutors {
      * {@link TransmittableThreadLocal} Wrapper of {@link ScheduledExecutorService},
      * transmit the {@link TransmittableThreadLocal} from the task submit time of {@link Runnable} or {@link java.util.concurrent.Callable}
      * to the execution time of {@link Runnable} or {@link java.util.concurrent.Callable}.
+     *
+     * @param scheduledExecutorService {@link ScheduledExecutorService} to be decorated
+     * @return decorated {@link ScheduledExecutorService}
      */
     @Nullable
     public static ScheduledExecutorService getTtlScheduledExecutorService(@Nullable ScheduledExecutorService scheduledExecutorService) {
@@ -78,6 +87,7 @@ public final class TtlExecutors {
      *
      * @param executor input executor
      * @param <T>      Executor type
+     * @return if it's a decorated Executor
      * @see #getTtlExecutor(Executor)
      * @see #getTtlExecutorService(ExecutorService)
      * @see #getTtlScheduledExecutorService(ScheduledExecutorService)
@@ -98,6 +108,7 @@ public final class TtlExecutors {
      *
      * @param executor input executor
      * @param <T>      Executor type
+     * @return original Executor
      * @see #getTtlExecutor(Executor)
      * @see #getTtlExecutorService(ExecutorService)
      * @see #getTtlScheduledExecutorService(ScheduledExecutorService)
@@ -116,6 +127,7 @@ public final class TtlExecutors {
      * Wrapper of  {@link ThreadFactory}, disable inheritable.
      *
      * @param threadFactory input thread factory
+     * @return decorated ThreadFactory without inheritable feature
      * @see DisableInheritableThreadFactory
      * @since 2.10.0
      */
@@ -129,6 +141,7 @@ public final class TtlExecutors {
     /**
      * Wrapper of {@link Executors#defaultThreadFactory()}, disable inheritable.
      *
+     * @return default ThreadFactory without inheritable feature
      * @see #getDisableInheritableThreadFactory(ThreadFactory)
      * @since 2.10.0
      */
@@ -140,6 +153,8 @@ public final class TtlExecutors {
     /**
      * check the {@link ThreadFactory} is {@link DisableInheritableThreadFactory} or not.
      *
+     * @param threadFactory ThreadFactory to be check
+     * @return if decorated
      * @see DisableInheritableThreadFactory
      * @since 2.10.0
      */
@@ -150,6 +165,8 @@ public final class TtlExecutors {
     /**
      * Unwrap {@link DisableInheritableThreadFactory} to the original/underneath one.
      *
+     * @param threadFactory ThreadFactory to be unwrapped
+     * @return original ThreadFactory before wrapped
      * @see DisableInheritableThreadFactory
      * @since 2.10.0
      */

--- a/src/main/java/com/alibaba/ttl/threadpool/TtlForkJoinPoolHelper.java
+++ b/src/main/java/com/alibaba/ttl/threadpool/TtlForkJoinPoolHelper.java
@@ -20,6 +20,7 @@ public class TtlForkJoinPoolHelper {
      * Wrapper of {@link ForkJoinWorkerThreadFactory}, disable inheritable.
      *
      * @param threadFactory input thread factory
+     * @return decorated ThreadFactory
      * @see DisableInheritableForkJoinWorkerThreadFactory
      * @since 2.10.1
      */
@@ -34,6 +35,7 @@ public class TtlForkJoinPoolHelper {
     /**
      * Wrapper of {@link ForkJoinPool#defaultForkJoinWorkerThreadFactory}, disable inheritable.
      *
+     * @return default decorated ForkJoinWorkerThreadFactory without inheritable feature
      * @see #getDisableInheritableForkJoinWorkerThreadFactory(ForkJoinWorkerThreadFactory)
      * @since 2.10.1
      */
@@ -45,6 +47,8 @@ public class TtlForkJoinPoolHelper {
     /**
      * check the {@link ForkJoinWorkerThreadFactory} is  {@link DisableInheritableForkJoinWorkerThreadFactory} or not.
      *
+     * @param threadFactory target ForkJoinWorkerThreadFactory
+     * @return if it's decorated
      * @see DisableInheritableForkJoinWorkerThreadFactory
      * @since 2.10.1
      */
@@ -55,6 +59,8 @@ public class TtlForkJoinPoolHelper {
     /**
      * Unwrap {@link DisableInheritableForkJoinWorkerThreadFactory} to the original/underneath one.
      *
+     * @param threadFactory target ForkJoinWorkerThreadFactory
+     * @return original ForkJoinWorkerThreadFactory
      * @see DisableInheritableForkJoinWorkerThreadFactory
      * @since 2.10.1
      */

--- a/src/main/java/com/alibaba/ttl/threadpool/agent/TtlAgent.java
+++ b/src/main/java/com/alibaba/ttl/threadpool/agent/TtlAgent.java
@@ -107,6 +107,9 @@ public final class TtlAgent {
      * <h3>Multi key configuration example</h3>
      * {@code -javaagent:/path/to/transmittable-thread-local-2.x.x.jar=ttl.agent.logger:STDOUT,ttl.agent.disable.inheritable.for.thread.pool:true}
      *
+     * @param agentArgs agent arguments
+     * @param inst      instrumentation
+     *
      * @see java.util.concurrent.ThreadPoolExecutor
      * @see java.util.concurrent.ScheduledThreadPoolExecutor
      * @see java.util.concurrent.ForkJoinPool
@@ -169,6 +172,8 @@ public final class TtlAgent {
     /**
      * Whether disable inheritable for thread pool is enhanced by ttl agent, check {@link #isTtlAgentLoaded()} first.
      *
+     * @return if inheritable should be disabled
+     *
      * @see com.alibaba.ttl.threadpool.TtlExecutors#getDefaultDisableInheritableThreadFactory()
      * @see com.alibaba.ttl.threadpool.TtlExecutors#getDisableInheritableThreadFactory(java.util.concurrent.ThreadFactory)
      * @see com.alibaba.ttl.threadpool.DisableInheritableThreadFactory
@@ -183,6 +188,8 @@ public final class TtlAgent {
 
     /**
      * Whether timer task is enhanced by ttl agent, check {@link #isTtlAgentLoaded()} first.
+     *
+     * @return if should enable timer task
      *
      * @since 2.10.1
      */
@@ -201,6 +208,9 @@ public final class TtlAgent {
 
     /**
      * Split to {@code json} like String({@code "k1:v1,k2:v2"}) to KV map({@code "k1"->"v1", "k2"->"v2"}).
+     *
+     * @param commaColonString comma colon string
+     * @return kv map by splitting string
      */
     @Nonnull
     static Map<String, String> splitCommaColonStringToKV(@Nullable String commaColonString) {

--- a/src/test/java/com/alibaba/ttl/user_api_test/TransmittableThreadLocal_Transmitter_UserTest.kt
+++ b/src/test/java/com/alibaba/ttl/user_api_test/TransmittableThreadLocal_Transmitter_UserTest.kt
@@ -6,7 +6,6 @@ import com.alibaba.support.junit.conditional.ConditionalIgnoreRule
 import com.alibaba.support.junit.conditional.ConditionalIgnoreRule.ConditionalIgnore
 import com.alibaba.ttl.TransmittableThreadLocal
 import com.alibaba.ttl.threadpool.TtlExecutors
-import com.alibaba.ttl.threadpool.agent.internal.transformlet.impl.TtlExecutorTransformlet
 import org.junit.AfterClass
 import org.junit.Assert.*
 import org.junit.Rule
@@ -169,11 +168,11 @@ class TransmittableThreadLocal_Transmitter_UserTest {
     }
 
     @Test
-    fun test_registerThreadLocal() {
+    fun test_transmitThreadLocal() {
         val ttl = ThreadLocal<String>()
         ttl.set(PARENT)
 
-        TransmittableThreadLocal.register(ttl)
+        TransmittableThreadLocal.transmit(ttl)
 
         val capture = TransmittableThreadLocal.Transmitter.capture()
 
@@ -196,7 +195,7 @@ class TransmittableThreadLocal_Transmitter_UserTest {
 
         assertEquals(PARENT, ttl.get())
 
-        TransmittableThreadLocal.unregister(ttl)
+        TransmittableThreadLocal.untransmit(ttl)
 
         val capture1 = TransmittableThreadLocal.Transmitter.capture()
 


### PR DESCRIPTION
Sometimes we need to use the thread local defined in thirdparty libraries.
Support register ThreadLocal to be transmitted with TransmittableThreadLocals.