### PR TITLE
fix:add synchronized to weakHashMap,avoid endless loop while updating…

### DIFF
--- a/src/main/java/com/alibaba/ttl/threadpool/agent/TtlExtensionTransformletManager.java
+++ b/src/main/java/com/alibaba/ttl/threadpool/agent/TtlExtensionTransformletManager.java
@@ -47,15 +47,15 @@ final class TtlExtensionTransformletManager {
     }
 
     // NOTE: use WeakHashMap as a Set collection, value is always null.
-    private final WeakHashMap<ClassLoader, ?> collectedClassLoaderHistory = new WeakHashMap<ClassLoader, Object>(512);
+    private final Map<ClassLoader, ?> collectedClassLoaderHistory = Collections.synchronizedMap(new WeakHashMap<ClassLoader, Object>(512));
 
     // Map: ExtensionTransformlet ClassLoader -> ExtensionTransformlet ClassName -> ExtensionTransformlet instance(not include from parent classloader)
-    private final WeakHashMap<ClassLoader, Map<String, TtlTransformlet>> classLoader2ExtensionTransformlets =
-        new WeakHashMap<ClassLoader, Map<String, TtlTransformlet>>(512);
+    private final Map<ClassLoader, Map<String, TtlTransformlet>> classLoader2ExtensionTransformlets =
+        Collections.synchronizedMap(new WeakHashMap<ClassLoader, Map<String, TtlTransformlet>>(512));
 
     // Map: ExtensionTransformlet ClassLoader -> ExtensionTransformlet ClassName -> ExtensionTransformlet instance(include from parent classloader)
-    private final WeakHashMap<ClassLoader, Map<String, TtlTransformlet>> classLoader2ExtensionTransformletsIncludeParentCL =
-        new WeakHashMap<ClassLoader, Map<String, TtlTransformlet>>(512);
+    private final Map<ClassLoader, Map<String, TtlTransformlet>> classLoader2ExtensionTransformletsIncludeParentCL =
+        Collections.synchronizedMap(new WeakHashMap<ClassLoader, Map<String, TtlTransformlet>>(512));
 
     public void collectExtensionTransformlet(@NonNull final ClassInfo classInfo) throws IOException {
         final ClassLoader classLoader = classInfo.getClassLoader();


### PR DESCRIPTION
在更新ExtensionTransformlets时使用到了WeakHashMap，在并发时，WeakHashMap在扩容的时候有一定概率形成环形链表，导致死循环，CPU飙升。