### PR TITLE
chore(ci): update CI config for Java-21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        java: [ 8, 11, 17, 20, 21-ea ]
+        java: [ 8, 11, 17, 20, 21 ]
       fail-fast: false
       max-parallel: 64
     name: Fast Test on Java ${{ matrix.java }} OS ${{ matrix.os }}

--- a/.github/workflows/strong_ci.yaml
+++ b/.github/workflows/strong_ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: setup Java 21
         uses: actions/setup-java@v3
         with:
-          java-version: 21-ea
+          java-version: 21
           distribution: zulu
 
       - name: run integration test


### PR DESCRIPTION
java 21已正式发布，ci环境中的`21-ea`版本视乎已经没有了

![image](https://github.com/alibaba/transmittable-thread-local/assets/5037807/9aeffa88-6950-445f-a444-9ad37267037b)
