### PR TITLE
chore(ci): add bytecode version verification plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,10 @@
 						</goals>
 						<configuration>
 							<rules>
+								<enforceBytecodeVersion>
+									<maxJdkVersion>${maven.compiler.source}</maxJdkVersion>
+									<ignoredScopes>test</ignoredScopes>
+								</enforceBytecodeVersion>
 								<requireMavenVersion>
 									<version>3.3.9</version>
 								</requireMavenVersion>
@@ -422,6 +426,13 @@
 						</configuration>
 					</execution>
 				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>extra-enforcer-rules</artifactId>
+						<version>1.7.0</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 		</plugins>
 		<pluginManagement>


### PR DESCRIPTION
增加字节码版本校验，便于在升级外部依赖时校验与本项目构建版本是否兼容.

例如 当我们试图升级`javassist-3.30.1-GA`时，能快速检测出它的构建版本为jdk11

```
[INFO] --- maven-enforcer-plugin:3.4.1:enforce (enforce-maven) @ ttl-agent ---
[INFO] Adding ignore: module-info
[INFO] Restricted to JDK 8 yet org.javassist:javassist:jar:3.30.1-GA:compile contains javassist/ByteArrayClassPath$BytecodeURLConnection.class targeted to JDK 11
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] ttl3-parent ........................................ SUCCESS [  0.431 s]
[INFO] TransmittableThreadLocal(TTL) ...................... SUCCESS [  8.068 s]
[INFO] TransmittableThreadLocal(TTL) Agent ................ FAILURE [  0.024 s]
[INFO] TransmittableThreadLocal(TTL) kotlin support ....... SKIPPED
[INFO] TransmittableThreadLocal(TTL) v2 compatible ........ SKIPPED
[INFO] ttl-bom ............................................ SKIPPED
[INFO] vertx4-ttl-integration ............................. SKIPPED
[INFO] vertx3-ttl-integration ............................. SKIPPED
[INFO] sample-ttl-agent-extension-transformlet ............ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 8.712 s
[INFO] Finished at: 2023-12-20T10:15:29+08:00
[INFO] Final Memory: 48M/901M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.4.1:enforce (enforce-maven) on project ttl-agent:
[ERROR] Rule 0: org.codehaus.mojo.extraenforcer.dependencies.EnforceBytecodeVersion failed with message:
[ERROR] Found Banned Dependency: org.javassist:javassist:jar:3.30.1-GA
[ERROR] Use 'mvn dependency:tree' to locate the source of the banned dependencies.
```