### PR TITLE
Enable TTL replay on CompletableFuture sync path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -636,7 +636,7 @@
         <ttl.built.agent.jar>
           ${project.build.directory}/${project.artifactId}-${project.version}.jar
         </ttl.built.agent.jar>
-        <ttl.agent.args>ttl.agent.logger:STDOUT</ttl.agent.args>
+        <ttl.agent.args>ttl.agent.logger:STDOUT,ttl.agent.enable.completion.transformlet:true</ttl.agent.args>
         <ttl.agent.extra.args/> <!-- overridden in maven -D options -->
         <ttl.agent.extra.d.options/> <!-- overridden in maven -D options -->
         <ttl.agent.jvm.arg>-javaagent:${ttl.built.agent.jar}=${ttl.agent.args},${ttl.agent.extra.args}</ttl.agent.jvm.arg>

--- a/src/main/java/com/alibaba/ttl/threadpool/agent/TtlAgent.java
+++ b/src/main/java/com/alibaba/ttl/threadpool/agent/TtlAgent.java
@@ -2,6 +2,7 @@ package com.alibaba.ttl.threadpool.agent;
 
 import com.alibaba.ttl.threadpool.agent.internal.logging.Logger;
 import com.alibaba.ttl.threadpool.agent.internal.transformlet.JavassistTransformlet;
+import com.alibaba.ttl.threadpool.agent.internal.transformlet.impl.TtlCompletionTransformlet;
 import com.alibaba.ttl.threadpool.agent.internal.transformlet.impl.TtlExecutorTransformlet;
 import com.alibaba.ttl.threadpool.agent.internal.transformlet.impl.TtlForkJoinTransformlet;
 import com.alibaba.ttl.threadpool.agent.internal.transformlet.impl.TtlPriorityBlockingQueueTransformlet;
@@ -139,7 +140,11 @@ public final class TtlAgent {
             transformletList.add(new TtlExecutorTransformlet(disableInheritableForThreadPool));
             transformletList.add(new TtlPriorityBlockingQueueTransformlet());
 
-            transformletList.add(new TtlForkJoinTransformlet(disableInheritableForThreadPool));
+            final TtlForkJoinTransformlet forkJoinTransformlet = new TtlForkJoinTransformlet(disableInheritableForThreadPool);
+            transformletList.add(forkJoinTransformlet);
+
+            // This transformlet must be added with forkJoinTransformlet!
+            if (isEnableCompletionTransformlet()) transformletList.add(new TtlCompletionTransformlet());
 
             if (isEnableTimerTask()) transformletList.add(new TtlTimerTaskTransformlet());
 
@@ -176,6 +181,8 @@ public final class TtlAgent {
 
     private static final String TTL_AGENT_ENABLE_TIMER_TASK_KEY = "ttl.agent.enable.timer.task";
 
+    private static final String TTL_AGENT_ENABLE_COMPLETION_TRANSFORMLET_KEY = "ttl.agent.enable.completion.transformlet";
+
     private static final String TTL_AGENT_DISABLE_INHERITABLE_FOR_THREAD_POOL = "ttl.agent.disable.inheritable.for.thread.pool";
 
     /**
@@ -191,6 +198,17 @@ public final class TtlAgent {
      */
     public static boolean isDisableInheritableForThreadPool() {
         return isBooleanOptionSet(kvs, TTL_AGENT_DISABLE_INHERITABLE_FOR_THREAD_POOL, false);
+    }
+
+    /**
+     * Whether {@link java.util.concurrent.CompletableFuture} completion stage context propagation
+     * is enhanced by ttl agent, check {@link #isTtlAgentLoaded()} first.
+     *
+     * @see TtlCompletionTransformlet
+     * @since 2.14.5
+     */
+    public static boolean isEnableCompletionTransformlet() {
+        return isBooleanOptionSet(kvs, TTL_AGENT_ENABLE_COMPLETION_TRANSFORMLET_KEY, false);
     }
 
     /**

--- a/src/main/java/com/alibaba/ttl/threadpool/agent/internal/transformlet/impl/TtlCompletionTransformlet.java
+++ b/src/main/java/com/alibaba/ttl/threadpool/agent/internal/transformlet/impl/TtlCompletionTransformlet.java
@@ -1,0 +1,289 @@
+package com.alibaba.ttl.threadpool.agent.internal.transformlet.impl;
+
+import com.alibaba.ttl.TransmittableThreadLocal;
+import com.alibaba.ttl.threadpool.agent.internal.logging.Logger;
+import com.alibaba.ttl.threadpool.agent.internal.transformlet.ClassInfo;
+import com.alibaba.ttl.threadpool.agent.internal.transformlet.JavassistTransformlet;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import javassist.*;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.logging.Level;
+
+import static com.alibaba.ttl.threadpool.agent.internal.transformlet.impl.TtlForkJoinTransformlet.capturedFieldName;
+import static com.alibaba.ttl.threadpool.agent.internal.transformlet.impl.Utils.*;
+
+/**
+ * TTL {@link JavassistTransformlet} for {@code java.util.concurrent.CompletableFuture$Completion}
+ * subclasses (e.g. {@code UniApply}, {@code UniAccept}, {@code BiApply}), so that they replay the
+ * captured TTL context even when they are triggered through the {@code tryFire} path.
+ *
+ * <h2>The problem</h2>
+ *
+ * <p>TTL context propagation does not work correctly on {@code CompletableFuture} completion stages,
+ * because the captured context is not replayed.
+ *
+ * <p>{@link TtlForkJoinTransformlet} instruments {@link java.util.concurrent.ForkJoinTask} so that
+ * each task captures the context at construction time. When the task runs, it is expected to:
+ *
+ * <ol>
+ *     <li>replay the captured context onto its executing thread;
+ *     <li>execute under that context;
+ *     <li>restore the executing thread to its previous state.
+ * </ol>
+ *
+ * <p>{@code CompletableFuture$Completion} extends {@code ForkJoinTask}, so TTL context propagation
+ * should work seamlessly. The problem is that {@code CompletableFuture} may greedily execute its
+ * completion stages, bypassing the {@code ForkJoinTask} interface. {@code Completion.tryFire} is the
+ * actual work of each completion stage; {@code ForkJoinTask} methods such as {@code doExec} simply
+ * call {@code tryFire(ASYNC)}. But when a {@code CompletableFuture} finishes, it calls
+ * {@code postComplete}, which iterates the completion stages and calls {@code tryFire} on each one
+ * directly instead of going through {@code doExec}. Because TTL only instruments {@code doExec},
+ * these completion stages execute without the replay/restore logic and so see the wrong context.
+ *
+ * <h2>The fix</h2>
+ *
+ * <p>Force the replay to happen inside the stored closure instead of relying on {@code doExec}, so
+ * that the context is replayed no matter how the completion stage is triggered ({@code tryFire} or
+ * {@code doExec}):
+ *
+ * <ol>
+ *     <li>match all subclasses of {@code Completion} that hold a functional interface field (named
+ *         {@code fn} consistently throughout the {@code CompletableFuture} source);
+ *     <li>insert code at the end of the constructors that assign that field, reassigning it to a
+ *         wrapped version — see the {@code wrap} overloads below;
+ *     <li>mark the class with {@link Enhanced}, so that {@link TtlForkJoinTransformlet} skips the
+ *         {@code doExec} replay for it and the context is not replayed twice.
+ * </ol>
+ *
+ * <h2>Ordering</h2>
+ *
+ * <p>Since UniCompose etc. classes extend ForkJoinTask, it is guaranteed that ForkJoinTask will load before UniCompose. Therefore, TtlForkJoinTransformlet will have already run. As long as TtlForkJoinTransformlet is loaded along with this transformlet, there is no ordering issue.</p>
+ *
+ * <p>{@code Completion} subclasses without a functional field ({@code UniRelay}, {@code BiRelay},
+ * {@code Signaller}, {@code AnyOf}, ...) run no user code, so they are left alone and keep the
+ * plain {@code doExec} instrumentation.
+ *
+ * @see TtlForkJoinTransformlet
+ * @see java.util.concurrent.CompletableFuture
+ * @since 2.14.5
+ */
+public class TtlCompletionTransformlet implements JavassistTransformlet {
+    /**
+     * Marker interface for the {@code Completion} subclasses instrumented by this transformlet.
+     * <p>
+     * Implementing it signals to {@link TtlForkJoinTransformlet} that {@code doExec} must
+     * <b>not</b> replay the captured context, because the wrapped {@code fn} already does.
+     */
+    public interface Enhanced {
+    }
+
+    private static final Logger logger = Logger.getLogger(TtlCompletionTransformlet.class);
+
+    private static final String COMPLETABLE_FUTURE_CLASS_NAME = "java.util.concurrent.CompletableFuture";
+    private static final String COMPLETION_CLASS_NAME = COMPLETABLE_FUTURE_CLASS_NAME + "$Completion";
+    private static final String FORK_JOIN_TASK_CLASS_NAME = "java.util.concurrent.ForkJoinTask";
+
+    private static final String WRAP_METHOD = TtlCompletionTransformlet.class.getName() + ".wrap";
+
+    static final List<String> supportedFunctionalInterfaces = Arrays.asList(
+            Runnable.class.getName(),
+            Function.class.getName(),
+            Consumer.class.getName(),
+            BiFunction.class.getName(),
+            BiConsumer.class.getName()
+    );
+
+    @Override
+    public void doTransform(@NonNull final ClassInfo classInfo) throws IOException, NotFoundException, CannotCompileException {
+        // cheap pre-filter before touching javassist: Completion is package-private to
+        // java.util.concurrent and all its subclasses are nested classes of CompletableFuture
+        if (!isClassOrInnerClass(classInfo.getClassName(), COMPLETABLE_FUTURE_CLASS_NAME)) {
+            return;
+        }
+
+        final CtClass clazz = classInfo.getCtClass();
+
+        if (!isCompletionSubclass(clazz)) {
+            return;
+        }
+
+        final CtField fnField = findFunctionalField(clazz);
+
+        if (fnField == null) {  // no wrappable field: e.g. UniRelay/Signaller, which run no user code
+            return;
+        }
+
+        final CtConstructor constructor = findConstructorAssignableToField(clazz, fnField.getType());
+
+        if (constructor == null) {
+            return;
+        }
+
+        // ClassInfo builds its ClassPool over the *original* class files, so the javassist compiler
+        // cannot see that field unless it is declared on ForkJoinTask in this pool too. This pool is
+        // never used to write ForkJoinTask back out, so the declaration is compile-time only.
+        declareTemporaryCapturedFieldOnForkJoinTask(clazz.getClassPool());
+
+        // The JDK declares these fields non-final (they are nulled out once the stage has fired);
+        // be defensive anyway, since the injected code assigns to the field.
+        if (Modifier.isFinal(fnField.getModifiers())) {
+            fnField.setModifiers(fnField.getModifiers() & ~Modifier.FINAL);
+        }
+
+        final String code = "this." + fnField.getName() + " = " + WRAP_METHOD
+            + "(this." + fnField.getName() + ", this." + capturedFieldName + ");";
+        logger.info("insert code after constructor " + signatureOfMethod(constructor) + " of class "
+                + clazz.getName() + ": " + code);
+        constructor.insertAfter(code);
+
+        // tell TtlForkJoinTransformlet to not replay again in doExec. Safe unconditionally:
+        // findFunctionalField only matches types that have a real, replaying wrap overload.
+        clazz.addInterface(clazz.getClassPool().get(Enhanced.class.getName()));
+
+        classInfo.setModified();
+    }
+
+    /**
+     * Whether {@code clazz} is {@code CompletableFuture$Completion} or a subclass of it.
+     * <p>
+     * {@link CtClass#subclassOf(CtClass)} matches on class name only and never touches the
+     * argument's {@link ClassPool}, so resolving {@code Completion} from {@code clazz}'s own pool
+     * is fine. Note it swallows a {@link NotFoundException} raised while walking the super chain
+     * and answers {@code false}; the {@link ClassPool#get} here still fails loudly if
+     * {@code Completion} itself cannot be resolved.
+     */
+    static boolean isCompletionSubclass(@NonNull final CtClass clazz) throws NotFoundException {
+        return clazz.subclassOf(clazz.getClassPool().get(COMPLETION_CLASS_NAME));
+    }
+
+    /**
+     * The (single, in practice) instance field of {@code clazz} whose type is one of
+     * {@link #supportedFunctionalInterfaces}.
+     * <p>
+     * Matching on the supported types rather than on {@code @FunctionalInterface} keeps
+     * instrumentation and the {@link #wrap} overloads in lockstep: a field this returns is always
+     * one the wrapper can actually replay for.
+     */
+    @Nullable
+    static CtField findFunctionalField(@NonNull final CtClass clazz) throws NotFoundException {
+        for (CtField field : clazz.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers()) && supportedFunctionalInterfaces.contains(field.getType().getName())) {
+                return field;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The constructor of {@code clazz} that take a parameter assignable to {@code fieldType},
+     * i.e. the one that can be assigning the functional field.
+     */
+    @Nullable
+    static CtConstructor findConstructorAssignableToField(@NonNull final CtClass clazz,
+                                                          @NonNull final CtClass fieldType) throws NotFoundException {
+        for (CtConstructor constructor : clazz.getDeclaredConstructors()) {
+            for (CtClass parameterType : constructor.getParameterTypes()) {
+                if (parameterType.subtypeOf(fieldType)) {
+                    return constructor;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Declare captured$field$added$by$ttl temporarily on ForkJoinTask class so that this agent's added code can reference it without compile error. This is not persisted, so does not conflict with TtlForkJoinTransformlet's declaration.
+     */
+    private static void declareTemporaryCapturedFieldOnForkJoinTask(@NonNull final ClassPool classPool)
+        throws NotFoundException, CannotCompileException {
+        final CtClass forkJoinTask = classPool.get(FORK_JOIN_TASK_CLASS_NAME);
+        // forkJoinTask is guaranteed to never have the field since it is obtained from a fresh ClassPool
+        forkJoinTask.addField(TtlForkJoinTransformlet.makeCapturedField(forkJoinTask));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // the wrappers, called from the code injected into the Completion constructors
+    ////////////////////////////////////////////////////////////////////////////////
+
+    public static Runnable wrap(final Runnable fn, final Object captured) {
+        return () -> {
+            final Object backup = TransmittableThreadLocal.Transmitter.replay(captured);
+            try {
+                fn.run();
+            } finally {
+                TransmittableThreadLocal.Transmitter.restore(backup);
+            }
+        };
+    }
+
+    public static <T, R> Function<T, R> wrap(final Function<T, R> fn, final Object captured) {
+        return t -> {
+            final Object backup = TransmittableThreadLocal.Transmitter.replay(captured);
+            try {
+                return fn.apply(t);
+            } finally {
+                TransmittableThreadLocal.Transmitter.restore(backup);
+            }
+        };
+    }
+
+    public static <T> Consumer<T> wrap(final Consumer<T> fn, final Object captured) {
+        return t -> {
+            final Object backup = TransmittableThreadLocal.Transmitter.replay(captured);
+            try {
+                fn.accept(t);
+            } finally {
+                TransmittableThreadLocal.Transmitter.restore(backup);
+            }
+        };
+    }
+
+    public static <T, U, R> BiFunction<T, U, R> wrap(final BiFunction<T, U, R> fn, final Object captured) {
+        return (t, u) -> {
+            final Object backup = TransmittableThreadLocal.Transmitter.replay(captured);
+            try {
+                return fn.apply(t, u);
+            } finally {
+                TransmittableThreadLocal.Transmitter.restore(backup);
+            }
+        };
+    }
+
+    public static <T, U> BiConsumer<T, U> wrap(final BiConsumer<T, U> fn, final Object captured) {
+        return (t, u) -> {
+            final Object backup = TransmittableThreadLocal.Transmitter.replay(captured);
+            try {
+                fn.accept(t, u);
+            } finally {
+                TransmittableThreadLocal.Transmitter.restore(backup);
+            }
+        };
+    }
+
+    /**
+     * Catch-all overload, selected by the javassist compiler for a functional field whose static
+     * type matches none of the overloads above.
+     * <p>
+     * {@link #findFunctionalField} only ever matches the types in
+     * {@link #supportedFunctionalInterfaces}, and every one of those has a real overload above, so
+     * this is unreachable in practice. If it is ever called, {@code supportedFunctionalInterfaces}
+     * and the {@code wrap} overloads have drifted apart.
+     * <p>
+     * There is no way to replay/restore a type whose shape we don't know, so it returns {@code fn}
+     * unwrapped. It logs at {@link Level#SEVERE} rather than {@code WARNING} on purpose: the default
+     * {@code STDERR} logger implementation discards everything below {@code SEVERE}, and dropping
+     * context propagation silently is exactly what this overload exists to prevent.
+     */
+    public static <T> T wrap(final T fn, final Object captured) {
+        logger.log(Level.SEVERE, "no wrap overload for functional interface type " + (fn == null ? "null" : fn.getClass().getName())
+            + ", TTL context will not be replayed for this CompletableFuture completion stage.", null);
+        return fn;
+    }
+}

--- a/src/main/java/com/alibaba/ttl/threadpool/agent/internal/transformlet/impl/TtlForkJoinTransformlet.java
+++ b/src/main/java/com/alibaba/ttl/threadpool/agent/internal/transformlet/impl/TtlForkJoinTransformlet.java
@@ -9,6 +9,7 @@ import javassist.*;
 
 import java.io.IOException;
 
+import static com.alibaba.ttl.threadpool.agent.TtlAgent.isEnableCompletionTransformlet;
 import static com.alibaba.ttl.threadpool.agent.internal.transformlet.impl.Utils.*;
 
 /**
@@ -21,6 +22,8 @@ import static com.alibaba.ttl.threadpool.agent.internal.transformlet.impl.Utils.
  * @since 2.5.1
  */
 public class TtlForkJoinTransformlet implements JavassistTransformlet {
+    public static final String capturedFieldName = "captured$field$added$by$ttl";
+
     private static final Logger logger = Logger.getLogger(TtlForkJoinTransformlet.class);
 
     private static final String FORK_JOIN_TASK_CLASS_NAME = "java.util.concurrent.ForkJoinTask";
@@ -45,23 +48,44 @@ public class TtlForkJoinTransformlet implements JavassistTransformlet {
     }
 
     /**
+     * Declares a {@link #capturedFieldName} field on {@link java.util.concurrent.ForkJoinTask}.
+     * <p>
+     * Single source of truth for the field's type and modifiers: besides the real field added here,
+     * {@link TtlCompletionTransformlet} declares it on {@code ForkJoinTask} in its own
+     * {@link ClassPool} so that the code it injects into the {@code Completion} subclasses can be
+     * compiled against it.
+     *
+     * @see TtlCompletionTransformlet
+     */
+    static CtField makeCapturedField(@NonNull final CtClass forkJoinTask) throws CannotCompileException {
+        return CtField.make("protected final Object " + capturedFieldName + ";", forkJoinTask);
+    }
+
+    /**
      * @see Utils#doCaptureWhenNotTtlEnhanced(java.lang.Object)
      */
     private void updateForkJoinTaskClass(@NonNull final CtClass clazz) throws CannotCompileException, NotFoundException {
         final String className = clazz.getName();
 
         // add new field
-        final String capturedFieldName = "captured$field$added$by$ttl";
-        final CtField capturedField = CtField.make("private final Object " + capturedFieldName + ";", clazz);
+        final CtField capturedField = makeCapturedField(clazz);
         clazz.addField(capturedField, "com.alibaba.ttl.threadpool.agent.internal.transformlet.impl.Utils.doCaptureWhenNotTtlEnhanced(this);");
         logger.info("add new field " + capturedFieldName + " to class " + className);
 
         final CtMethod doExecMethod = clazz.getDeclaredMethod("doExec", new CtClass[0]);
         final String doExec_renamed_method_name = renamedMethodNameByTtl(doExecMethod);
 
+        // Prevents double replay on classes instrumented by TtlCompletionTransformlet
+        final String completionGuard = isEnableCompletionTransformlet()
+                ? "if (this instanceof " + TtlCompletionTransformlet.Enhanced.class.getName() + ") {\n" +
+                  "    return " + doExec_renamed_method_name + "($$);\n" +
+                  "}\n"
+                : "";
+
         final String beforeCode = "if (this instanceof " + TtlEnhanced.class.getName() + ") {\n" + // if the class is already TTL enhanced(eg: com.alibaba.ttl.TtlRecursiveTask)
                 "    return " + doExec_renamed_method_name + "($$);\n" +                           // return directly/do nothing
                 "}\n" +
+                completionGuard +
                 "Object backup = com.alibaba.ttl.TransmittableThreadLocal.Transmitter.replay(" + capturedFieldName + ");";
 
         final String finallyCode = "com.alibaba.ttl.TransmittableThreadLocal.Transmitter.restore(backup);";

--- a/src/test/java/com/alibaba/ttl/threadpool/agent/CompletableFutureDefaultBehaviorTest.kt
+++ b/src/test/java/com/alibaba/ttl/threadpool/agent/CompletableFutureDefaultBehaviorTest.kt
@@ -1,0 +1,156 @@
+package com.alibaba.ttl.threadpool.agent
+
+import com.alibaba.noTtlAgentRun
+import com.alibaba.ttl.TransmittableThreadLocal
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.core.test.config.TestCaseConfig
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+private const val CREATOR = "creator"
+private const val COMPLETER = "completer"
+private const val TIMEOUT_SECONDS = 5L
+
+/**
+ * Asserts the **default** (broken) behavior when the completion transformlet is not active:
+ * completion stages triggered via the `tryFire` path see the completing thread's context instead
+ * of the context captured when the stage was created.
+ *
+ * This is the counterpart to [CompletableFutureTtlTest], which asserts the fixed behavior.
+ * Together they document both sides of the contract:
+ * - without the fix (this class): stages see [COMPLETER]
+ * - with the fix ([CompletableFutureTtlTest]): stages see [CREATOR]
+ *
+ * These tests run only in the plain (no-agent) surefire execution, which is equivalent to having
+ * the agent loaded with `ttl.agent.enable.completion.transformlet:false` for the tryFire path:
+ * neither configuration wraps the `fn` field, so `postComplete` fires the raw closure on the
+ * completing thread's context.
+ */
+class CompletableFutureDefaultBehaviorTest : AnnotationSpec() {
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun defaultTestCaseConfig(): TestCaseConfig = TestCaseConfig(enabled = noTtlAgentRun())
+
+    private lateinit var ttl: TransmittableThreadLocal<String>
+
+    @BeforeEach
+    fun setUp() {
+        ttl = TransmittableThreadLocal()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        ttl.remove()
+    }
+
+    private fun completeOnOtherThread(completeAction: () -> Unit) {
+        val thread = Thread {
+            ttl.set(COMPLETER)
+            completeAction()
+        }
+        thread.start()
+        thread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS))
+        withClue("completer thread must have finished") {
+            thread.isAlive shouldBe false
+        }
+    }
+
+    @Test
+    fun thenApply_sees_completer_context_without_completion_transformlet() {
+        ttl.set(CREATOR)
+        val future = CompletableFuture<String>()
+        val stage = future.thenApply { ttl.get() }
+
+        completeOnOtherThread { future.complete("x") }
+
+        withClue("without the completion transformlet, tryFire runs under the completer's context") {
+            stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe COMPLETER
+        }
+    }
+
+    @Test
+    fun thenAccept_sees_completer_context_without_completion_transformlet() {
+        ttl.set(CREATOR)
+        val observed = AtomicReference<String?>()
+        val future = CompletableFuture<String>()
+        val stage = future.thenAccept { observed.set(ttl.get()) }
+
+        completeOnOtherThread { future.complete("x") }
+
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        withClue("without the completion transformlet, tryFire runs under the completer's context") {
+            observed.get() shouldBe COMPLETER
+        }
+    }
+
+    @Test
+    fun thenRun_sees_completer_context_without_completion_transformlet() {
+        ttl.set(CREATOR)
+        val observed = AtomicReference<String?>()
+        val future = CompletableFuture<String>()
+        val stage = future.thenRun { observed.set(ttl.get()) }
+
+        completeOnOtherThread { future.complete("x") }
+
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        withClue("without the completion transformlet, tryFire runs under the completer's context") {
+            observed.get() shouldBe COMPLETER
+        }
+    }
+
+    @Test
+    fun whenComplete_sees_completer_context_without_completion_transformlet() {
+        ttl.set(CREATOR)
+        val observed = AtomicReference<String?>()
+        val future = CompletableFuture<String>()
+        val stage = future.whenComplete { _, _ -> observed.set(ttl.get()) }
+
+        completeOnOtherThread { future.complete("x") }
+
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        withClue("without the completion transformlet, tryFire runs under the completer's context") {
+            observed.get() shouldBe COMPLETER
+        }
+    }
+
+    @Test
+    fun handle_sees_completer_context_without_completion_transformlet() {
+        ttl.set(CREATOR)
+        val future = CompletableFuture<String>()
+        val stage = future.handle { _, _ -> ttl.get() }
+
+        completeOnOtherThread { future.complete("x") }
+
+        withClue("without the completion transformlet, tryFire runs under the completer's context") {
+            stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe COMPLETER
+        }
+    }
+
+    @Test
+    fun thenCompose_sees_completer_context_without_completion_transformlet() {
+        ttl.set(CREATOR)
+        val future = CompletableFuture<String>()
+        val stage = future.thenCompose { CompletableFuture.completedFuture(ttl.get()) }
+
+        completeOnOtherThread { future.complete("x") }
+
+        withClue("without the completion transformlet, tryFire runs under the completer's context") {
+            stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe COMPLETER
+        }
+    }
+
+    @Test
+    fun exceptionally_sees_completer_context_without_completion_transformlet() {
+        ttl.set(CREATOR)
+        val future = CompletableFuture<String>()
+        val stage = future.exceptionally { ttl.get() }
+
+        completeOnOtherThread { future.completeExceptionally(RuntimeException("boom")) }
+
+        withClue("without the completion transformlet, tryFire runs under the completer's context") {
+            stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe COMPLETER
+        }
+    }
+}

--- a/src/test/java/com/alibaba/ttl/threadpool/agent/CompletableFutureTtlTest.kt
+++ b/src/test/java/com/alibaba/ttl/threadpool/agent/CompletableFutureTtlTest.kt
@@ -486,33 +486,44 @@ class TtlCompletionTransformletRequiresForkJoinTransformletTest : AnnotationSpec
 
     @Suppress("UNCHECKED_CAST")
     private fun callPremainAndGetTransformletList(agentArgs: String): List<JavassistTransformlet> {
-        // Reset Logger's impl type so premain can set it again
         val loggerImplTypeField = com.alibaba.ttl.threadpool.agent.internal.logging.Logger::class.java
             .getDeclaredField("loggerImplType")
         loggerImplTypeField.isAccessible = true
-        loggerImplTypeField.setInt(null, -1)
+        val originalLoggerImplType = loggerImplTypeField.getInt(null)
 
-        // Reset ttlAgentLoaded so premain doesn't short-circuit
         val loadedField = TtlAgent::class.java.getDeclaredField("ttlAgentLoaded")
         loadedField.isAccessible = true
-        loadedField.setBoolean(null, false)
+        val originalLoaded = loadedField.getBoolean(null)
 
-        var capturedTransformer: java.lang.instrument.ClassFileTransformer? = null
-        val mockInst = java.lang.reflect.Proxy.newProxyInstance(
-            Instrumentation::class.java.classLoader,
-            arrayOf(Instrumentation::class.java)
-        ) { _, method, args ->
-            if (method.name == "addTransformer") {
-                capturedTransformer = args[0] as java.lang.instrument.ClassFileTransformer
-            }
-            null
-        } as Instrumentation
+        val kvsField = TtlAgent::class.java.getDeclaredField("kvs")
+        kvsField.isAccessible = true
+        val originalKvs = kvsField.get(null)
 
-        TtlAgent.premain(agentArgs, mockInst)
+        try {
+            loggerImplTypeField.setInt(null, -1)
+            loadedField.setBoolean(null, false)
 
-        val transformer = capturedTransformer!!
-        val field = TtlTransformer::class.java.getDeclaredField("transformletList")
-        field.isAccessible = true
-        return field.get(transformer) as List<JavassistTransformlet>
+            var capturedTransformer: java.lang.instrument.ClassFileTransformer? = null
+            val mockInst = java.lang.reflect.Proxy.newProxyInstance(
+                Instrumentation::class.java.classLoader,
+                arrayOf(Instrumentation::class.java)
+            ) { _, method, args ->
+                if (method.name == "addTransformer") {
+                    capturedTransformer = args[0] as java.lang.instrument.ClassFileTransformer
+                }
+                null
+            } as Instrumentation
+
+            TtlAgent.premain(agentArgs, mockInst)
+
+            val transformer = capturedTransformer!!
+            val field = TtlTransformer::class.java.getDeclaredField("transformletList")
+            field.isAccessible = true
+            return field.get(transformer) as List<JavassistTransformlet>
+        } finally {
+            loggerImplTypeField.setInt(null, originalLoggerImplType)
+            loadedField.setBoolean(null, originalLoaded)
+            kvsField.set(null, originalKvs)
+        }
     }
 }

--- a/src/test/java/com/alibaba/ttl/threadpool/agent/CompletableFutureTtlTest.kt
+++ b/src/test/java/com/alibaba/ttl/threadpool/agent/CompletableFutureTtlTest.kt
@@ -1,0 +1,518 @@
+package com.alibaba.ttl.threadpool.agent
+
+import com.alibaba.expandThreadPool
+import com.alibaba.hasTtlAgentRun
+import com.alibaba.noTtlAgentRun
+import com.alibaba.ttl.TransmittableThreadLocal
+import com.alibaba.ttl.threadpool.agent.internal.transformlet.JavassistTransformlet
+import com.alibaba.ttl.threadpool.agent.internal.transformlet.impl.TtlCompletionTransformlet
+import com.alibaba.ttl.threadpool.agent.internal.transformlet.impl.TtlForkJoinTransformlet
+import io.kotest.assertions.withClue
+import java.lang.instrument.Instrumentation
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.core.test.config.TestCaseConfig
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.ForkJoinPool
+import java.util.concurrent.ForkJoinTask
+import java.util.concurrent.RecursiveTask
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicReferenceArray
+
+private const val CREATOR = "creator"
+private const val COMPLETER = "completer"
+private const val MUTATED_BY_STAGE = "mutated-by-stage"
+private const val COMPLETER_ONLY = "completer-only"
+private const val NOT_RUN = "not-run"
+private const val TIMEOUT_SECONDS = 5L
+private const val CHAIN_DEPTH = 10
+private const val CF_PREFIX = "java.util.concurrent.CompletableFuture$"
+private const val CF_ASYNC_SUPPLY = CF_PREFIX + "AsyncSupply"
+
+/**
+ * Regression tests for the `CompletableFuture` completion-stage context propagation bug fixed by
+ * [TtlCompletionTransformlet].
+ *
+ * `CompletableFuture` completion stages (`thenApply`, `thenAccept`, ...) extend `ForkJoinTask`, and
+ * TTL normally captures context when a `ForkJoinTask` is constructed and replays it in `doExec`.
+ * But `CompletableFuture.postComplete()` fires most stages by calling `Completion.tryFire(...)`
+ * *directly*, bypassing `doExec` entirely -- so, before the fix, a stage ran with whichever
+ * thread's context happened to complete the future, instead of the context captured when the
+ * stage itself was created.
+ *
+ * These tests create a stage while a [TransmittableThreadLocal] is set to [CREATOR] on the
+ * current (Kotest) thread, then complete the underlying future from a *different* thread whose
+ * own value is [COMPLETER]. Without the agent (and without the fix), the stage would observe
+ * [COMPLETER]; with the fix it must observe [CREATOR]. This whole spec is meaningless without the
+ * agent attached, so it is disabled outside the `-Penable-ttl-agent-for-test` run.
+ *
+ * @see TtlCompletionTransformlet
+ */
+class CompletableFutureTtlTest : AnnotationSpec() {
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun defaultTestCaseConfig(): TestCaseConfig = TestCaseConfig(enabled = hasTtlAgentRun())
+
+    private lateinit var ttl: TransmittableThreadLocal<String>
+
+    @BeforeEach
+    fun setUp() {
+        ttl = TransmittableThreadLocal()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        ttl.remove()
+    }
+
+    /**
+     * Runs [completeAction] on a fresh thread that first sets [ttl] to [COMPLETER], then joins
+     * that thread (bounded by [TIMEOUT_SECONDS], so a regression hangs the suite for seconds, not
+     * forever) and asserts the completer thread's *own* value was [COMPLETER] right up to the end
+     * of [completeAction] -- i.e. that replaying the creator's captured context into the stage did
+     * not leak into, or fail to be restored on, the thread that actually completed the future.
+     */
+    private fun completeOnOtherThread(completeAction: () -> Unit) {
+        val completerValueAfterComplete = AtomicReference<String?>()
+        val completerThread = Thread {
+            ttl.set(COMPLETER)
+            completeAction()
+            completerValueAfterComplete.set(ttl.get())
+        }
+        completerThread.start()
+        completerThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS))
+
+        withClue("completer thread must have finished within $TIMEOUT_SECONDS seconds") {
+            completerThread.isAlive shouldBe false
+        }
+        withClue("completer thread's own TTL value must be restored (not leaked into) after completing the future") {
+            completerValueAfterComplete.get() shouldBe COMPLETER
+        }
+    }
+
+    @Test
+    fun thenApply_sees_context_captured_at_stage_creation() {
+        ttl.set(CREATOR)
+        val future = CompletableFuture<String>()
+        val stage = future.thenApply { v -> "$v:${ttl.get()}" }
+
+        completeOnOtherThread { future.complete("value") }
+
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe "value:$CREATOR"
+    }
+
+    @Test
+    fun thenAccept_sees_context_captured_at_stage_creation() {
+        ttl.set(CREATOR)
+        val observed = AtomicReference<String?>()
+        val future = CompletableFuture<String>()
+        val stage = future.thenAccept { observed.set(ttl.get()) }
+
+        completeOnOtherThread { future.complete("value") }
+
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        observed.get() shouldBe CREATOR
+    }
+
+    @Test
+    fun thenRun_sees_context_captured_at_stage_creation() {
+        ttl.set(CREATOR)
+        val observed = AtomicReference<String?>()
+        val future = CompletableFuture<String>()
+        val stage = future.thenRun { observed.set(ttl.get()) }
+
+        completeOnOtherThread { future.complete("value") }
+
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        observed.get() shouldBe CREATOR
+    }
+
+    @Test
+    fun whenComplete_sees_context_captured_at_stage_creation() {
+        ttl.set(CREATOR)
+        val observed = AtomicReference<String?>()
+        val future = CompletableFuture<String>()
+        val stage = future.whenComplete { _, _ -> observed.set(ttl.get()) }
+
+        completeOnOtherThread { future.complete("value") }
+
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        observed.get() shouldBe CREATOR
+    }
+
+    @Test
+    fun handle_sees_context_captured_at_stage_creation() {
+        ttl.set(CREATOR)
+        val future = CompletableFuture<String>()
+        val stage = future.handle { v, _ -> "$v:${ttl.get()}" }
+
+        completeOnOtherThread { future.complete("value") }
+
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe "value:$CREATOR"
+    }
+
+    @Test
+    fun thenCompose_sees_context_captured_at_stage_creation() {
+        ttl.set(CREATOR)
+        val future = CompletableFuture<String>()
+        val stage = future.thenCompose { v -> CompletableFuture.completedFuture("$v:${ttl.get()}") }
+
+        completeOnOtherThread { future.complete("value") }
+
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe "value:$CREATOR"
+    }
+
+    @Test
+    fun thenCombine_sees_context_captured_at_stage_creation() {
+        ttl.set(CREATOR)
+        val future = CompletableFuture<String>()
+        val other = CompletableFuture.completedFuture("other")
+        val stage = future.thenCombine(other) { v, o -> "$v:$o:${ttl.get()}" }
+
+        completeOnOtherThread { future.complete("value") }
+
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe "value:other:$CREATOR"
+    }
+
+    @Test
+    fun exceptionally_sees_context_captured_at_stage_creation() {
+        ttl.set(CREATOR)
+        val future = CompletableFuture<String>()
+        val stage = future.exceptionally { "handled:${ttl.get()}" }
+
+        completeOnOtherThread { future.completeExceptionally(RuntimeException("boom")) }
+
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe "handled:$CREATOR"
+    }
+
+    @Test
+    fun thenApplyAsync_with_explicit_executor_still_sees_context_and_is_not_broken_by_the_fix() {
+        val executor: ExecutorService = Executors.newFixedThreadPool(4)
+        try {
+            expandThreadPool(executor)
+
+            ttl.set(CREATOR)
+            val future = CompletableFuture<String>()
+            val stage = future.thenApplyAsync({ v -> "$v:${ttl.get()}" }, executor)
+
+            completeOnOtherThread { future.complete("value") }
+
+            // this variant fires via ForkJoinTask#doExec (not the direct tryFire path), so this
+            // guards against the fix double-replaying (or otherwise breaking) that existing path.
+            stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe "value:$CREATOR"
+        } finally {
+            executor.shutdown()
+        }
+    }
+
+    @Test
+    fun thenApplyAsync_with_default_ForkJoinPool_still_sees_context_and_is_not_broken_by_the_fix() {
+        ttl.set(CREATOR)
+        val future = CompletableFuture<String>()
+        val stage = future.thenApplyAsync { v -> "$v:${ttl.get()}" }
+
+        completeOnOtherThread { future.complete("value") }
+
+        // this variant fires via ForkJoinTask#doExec on the common pool (not the direct tryFire
+        // path), so this guards against the fix double-replaying (or otherwise breaking) it.
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe "value:$CREATOR"
+    }
+
+    @Test
+    fun mutating_ttl_after_stage_creation_but_before_completion_is_not_visible_to_the_stage() {
+        ttl.set(CREATOR)
+        val future = CompletableFuture<String>()
+        val stage = future.thenApply { v -> "$v:${ttl.get()}" }
+
+        // mutate on the creator thread, strictly after the stage was created: this must not be
+        // visible to the stage function, since capture happens at construction time.
+        ttl.set("mutated-after-stage-creation")
+
+        completeOnOtherThread { future.complete("value") }
+
+        withClue("stage must see the value captured at stage-creation time, not a later mutation") {
+            stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe "value:$CREATOR"
+        }
+    }
+
+    @Test
+    fun chained_thenApply_stages_all_see_the_creator_context() {
+        ttl.set(CREATOR)
+        val future = CompletableFuture<String>()
+        val stage = future
+            .thenApply { v -> "$v:${ttl.get()}" }
+            .thenApply { v -> "$v:${ttl.get()}" }
+
+        completeOnOtherThread { future.complete("value") }
+
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe "value:$CREATOR:$CREATOR"
+    }
+
+    /**
+     * A [CHAIN_DEPTH]-deep chain in which the creator writes a *different* value before creating
+     * each stage, and every stage then overwrites the context from inside its own body.
+     *
+     * Each stage captures at its own construction, so each must observe its own creator value --
+     * not the one the previous stage wrote, and not the one the creator ended up with. The whole
+     * chain fires on the completing thread, nested inside a single `postComplete()`, so this also
+     * pins down that [CHAIN_DEPTH] replay/restore pairs unwind in order and leave that thread clean.
+     */
+    @Test
+    fun a_long_chain_where_every_stage_mutates_the_context() {
+        val seenByStage = AtomicReferenceArray<String?>(CHAIN_DEPTH)
+
+        val future = CompletableFuture<String>()
+        var stage: CompletableFuture<String> = future
+        for (i in 0 until CHAIN_DEPTH) {
+            // the creator context differs for every stage, so "each stage sees its own capture" and
+            // "every stage sees the creator's latest value" are distinguishable outcomes
+            ttl.set("$CREATOR-$i")
+            stage = stage.thenApply { v ->
+                seenByStage.set(i, ttl.get())
+                // ...and every stage clobbers the context it was given
+                ttl.set("$MUTATED_BY_STAGE-$i")
+                "$v>$i"
+            }
+        }
+        val creatorValueAfterBuildingTheChain = ttl.get()
+
+        // asserts the completing thread is back to COMPLETER once all CHAIN_DEPTH stages have run
+        completeOnOtherThread { future.complete("start") }
+
+        stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe
+            (0 until CHAIN_DEPTH).joinToString(separator = "", prefix = "start") { ">$it" }
+
+        for (i in 0 until CHAIN_DEPTH) {
+            withClue("stage #$i must see the context captured when *it* was created") {
+                seenByStage.get(i) shouldBe "$CREATOR-$i"
+            }
+        }
+        withClue("the creator thread must be untouched by the whole chain") {
+            ttl.get() shouldBe creatorValueAfterBuildingTheChain
+        }
+    }
+
+    @Test
+    fun a_ttl_written_by_the_stage_does_not_leak_into_the_completing_thread() {
+        ttl.set(CREATOR)
+        val future = CompletableFuture<String>()
+        val stage = future.thenApply { v ->
+            // the stage body runs under the *replayed* creator context; whatever it writes there
+            // must be undone by the restore, rather than left behind on the thread that fired it
+            ttl.set(MUTATED_BY_STAGE)
+            "$v:${ttl.get()}"
+        }
+
+        // completeOnOtherThread asserts the completing thread is back to COMPLETER afterwards --
+        // which, unlike the tests above, the restore now has real work to undo
+        completeOnOtherThread { future.complete("value") }
+
+        withClue("the stage must observe its own write while it is running") {
+            stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe "value:$MUTATED_BY_STAGE"
+        }
+        withClue("the creator thread must be unaffected by what the stage wrote") {
+            ttl.get() shouldBe CREATOR
+        }
+    }
+
+    @Test
+    fun a_ttl_set_only_on_the_completing_thread_is_not_visible_to_the_stage() {
+        // this TTL is never set on the creator thread, so it is absent from the snapshot captured
+        // at stage creation. Replaying that snapshot must *clear* it for the duration of the stage
+        // -- propagation is "install the captured context", not "add to whatever is already there".
+        val completerOnlyTtl = TransmittableThreadLocal<String>()
+        try {
+            ttl.set(CREATOR)
+            val observedInStage = AtomicReference<String?>(NOT_RUN)
+            val observedOnCompleterAfterwards = AtomicReference<String?>()
+
+            val future = CompletableFuture<String>()
+            val stage = future.thenApply { v ->
+                observedInStage.set(completerOnlyTtl.get())
+                v
+            }
+
+            val completerThread = Thread {
+                ttl.set(COMPLETER)
+                completerOnlyTtl.set(COMPLETER_ONLY)
+                future.complete("value")
+                observedOnCompleterAfterwards.set(completerOnlyTtl.get())
+            }
+            completerThread.start()
+            completerThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS))
+            completerThread.isAlive shouldBe false
+
+            stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe "value"
+            withClue("a TTL absent from the captured snapshot must not be visible inside the stage") {
+                observedInStage.get() shouldBe null
+            }
+            withClue("...but must be restored on the completing thread once the stage is done") {
+                observedOnCompleterAfterwards.get() shouldBe COMPLETER_ONLY
+            }
+        } finally {
+            completerOnlyTtl.remove()
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // The fix makes ForkJoinTask#doExec skip its replay for anything marked
+    // TtlCompletionTransformlet.Enhanced. These guard the other side of that branch:
+    // everything NOT marked must still get the plain doExec replay it had before.
+    ////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * A plain [ForkJoinTask] is never marked [TtlCompletionTransformlet.Enhanced], so `doExec` must
+     * still replay for it.
+     *
+     * Unlike a `CompletableFuture` stage, a task can be *constructed* and *submitted* from different
+     * threads, which is what makes this discriminating: the task captures [CREATOR] at construction,
+     * is submitted from a thread holding [COMPLETER], and runs on a pool worker holding neither.
+     */
+    @Test
+    fun a_plain_fork_join_task_is_not_enhanced_and_still_replays_via_doExec() {
+        withClue("a plain ForkJoinTask must not be marked Enhanced -- it needs the doExec replay") {
+            TtlCompletionTransformlet.Enhanced::class.java.isAssignableFrom(ReadTtlTask::class.java) shouldBe false
+        }
+
+        val pool = ForkJoinPool(2)
+        try {
+            ttl.set(CREATOR)
+            // constructed here, so ForkJoinTask's captured field holds CREATOR
+            val task = ReadTtlTask(ttl)
+
+            val computed = AtomicReference<String?>(NOT_RUN)
+            val submitter = Thread {
+                ttl.set(COMPLETER)
+                computed.set(pool.invoke(task))
+            }
+            submitter.start()
+            submitter.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS))
+            submitter.isAlive shouldBe false
+
+            withClue("doExec must replay the context captured when the task was constructed") {
+                computed.get() shouldBe CREATOR
+            }
+        } finally {
+            pool.shutdown()
+        }
+    }
+
+    /**
+     * `supplyAsync` runs an `AsyncSupply`, which extends [ForkJoinTask] but is *not* a `Completion`
+     * -- so it is not marked [TtlCompletionTransformlet.Enhanced] and keeps the `doExec` replay.
+     */
+    @Test
+    fun asyncSupply_is_not_enhanced_and_still_replays_via_doExec() {
+        withClue("AsyncSupply is a ForkJoinTask but not a Completion, so it must keep the doExec replay") {
+            TtlCompletionTransformlet.Enhanced::class.java
+                .isAssignableFrom(Class.forName(CF_ASYNC_SUPPLY)) shouldBe false
+        }
+
+        val pool = ForkJoinPool(1)
+        try {
+            // create the pool's worker from a thread holding COMPLETER: the worker inherits that
+            // (or, with "disable inheritable" enabled, nothing) -- either way not CREATOR, so a
+            // missing replay cannot masquerade as a passing test
+            val warmUp = Thread {
+                ttl.set(COMPLETER)
+                pool.submit { }.get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            }
+            warmUp.start()
+            warmUp.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS))
+            warmUp.isAlive shouldBe false
+
+            ttl.set(CREATOR)
+            val stage = CompletableFuture.supplyAsync({ ttl.get() }, pool)
+
+            withClue("doExec must replay the context captured when the AsyncSupply was constructed") {
+                stage.get(TIMEOUT_SECONDS, TimeUnit.SECONDS) shouldBe CREATOR
+            }
+        } finally {
+            pool.shutdown()
+        }
+    }
+}
+
+private class ReadTtlTask(private val ttl: TransmittableThreadLocal<String>) : RecursiveTask<String>() {
+    override fun compute(): String? = ttl.get()
+}
+
+/**
+ * Verifies the structural invariant: if [TtlCompletionTransformlet] is in the transformlet list
+ * built by [TtlAgent.premain], then [TtlForkJoinTransformlet] must also be present.
+ *
+ * Calls [TtlAgent.premain] with a mock [Instrumentation], captures the [TtlTransformer] passed
+ * to [Instrumentation.addTransformer], and reflectively reads its transformlet list.
+ */
+class TtlCompletionTransformletRequiresForkJoinTransformletTest : AnnotationSpec() {
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun defaultTestCaseConfig(): TestCaseConfig = TestCaseConfig(enabled = noTtlAgentRun())
+
+    @Test
+    fun premain_registers_ForkJoinTransformlet_when_CompletionTransformlet_is_enabled() {
+        val transformlets = callPremainAndGetTransformletList(
+            "ttl.agent.logger:STDERR,ttl.agent.enable.completion.transformlet:true"
+        )
+
+        val hasCompletion = transformlets.any { it is TtlCompletionTransformlet }
+        val hasForkJoin = transformlets.any { it is TtlForkJoinTransformlet }
+
+        withClue("completion transformlet should be registered when explicitly enabled") {
+            hasCompletion shouldBe true
+        }
+        withClue("ForkJoinTransformlet must be present whenever CompletionTransformlet is") {
+            hasForkJoin shouldBe true
+        }
+    }
+
+    @Test
+    fun premain_still_registers_ForkJoinTransformlet_when_CompletionTransformlet_is_disabled() {
+        val transformlets = callPremainAndGetTransformletList(
+            "ttl.agent.logger:STDERR,ttl.agent.enable.completion.transformlet:false"
+        )
+
+        val hasCompletion = transformlets.any { it is TtlCompletionTransformlet }
+        val hasForkJoin = transformlets.any { it is TtlForkJoinTransformlet }
+
+        withClue("completion transformlet should not be registered when disabled") {
+            hasCompletion shouldBe false
+        }
+        withClue("ForkJoinTransformlet must always be present regardless of completion flag") {
+            hasForkJoin shouldBe true
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun callPremainAndGetTransformletList(agentArgs: String): List<JavassistTransformlet> {
+        // Reset Logger's impl type so premain can set it again
+        val loggerImplTypeField = com.alibaba.ttl.threadpool.agent.internal.logging.Logger::class.java
+            .getDeclaredField("loggerImplType")
+        loggerImplTypeField.isAccessible = true
+        loggerImplTypeField.setInt(null, -1)
+
+        // Reset ttlAgentLoaded so premain doesn't short-circuit
+        val loadedField = TtlAgent::class.java.getDeclaredField("ttlAgentLoaded")
+        loadedField.isAccessible = true
+        loadedField.setBoolean(null, false)
+
+        var capturedTransformer: java.lang.instrument.ClassFileTransformer? = null
+        val mockInst = java.lang.reflect.Proxy.newProxyInstance(
+            Instrumentation::class.java.classLoader,
+            arrayOf(Instrumentation::class.java)
+        ) { _, method, args ->
+            if (method.name == "addTransformer") {
+                capturedTransformer = args[0] as java.lang.instrument.ClassFileTransformer
+            }
+            null
+        } as Instrumentation
+
+        TtlAgent.premain(agentArgs, mockInst)
+
+        val transformer = capturedTransformer!!
+        val field = TtlTransformer::class.java.getDeclaredField("transformletList")
+        field.isAccessible = true
+        return field.get(transformer) as List<JavassistTransformlet>
+    }
+}

--- a/src/test/java/com/alibaba/ttl/threadpool/agent/TtlAgentTest.kt
+++ b/src/test/java/com/alibaba/ttl/threadpool/agent/TtlAgentTest.kt
@@ -33,4 +33,5 @@ class TtlAgentTest : AnnotationSpec() {
         splitCommaColonStringToKV("     k1     :v1  , ttl.agent.logger    :STDOUT   ,k3") shouldBe
                 mapOf("k1" to "v1", "ttl.agent.logger" to "STDOUT", "k3" to "")
     }
+
 }

--- a/src/test/java/com/alibaba/ttl/threadpool/agent/internal/transformlet/impl/TtlCompletionTransformletTest.kt
+++ b/src/test/java/com/alibaba/ttl/threadpool/agent/internal/transformlet/impl/TtlCompletionTransformletTest.kt
@@ -1,0 +1,370 @@
+package com.alibaba.ttl.threadpool.agent.internal.transformlet.impl
+
+import com.alibaba.noTtlAgentRun
+import com.alibaba.ttl.TransmittableThreadLocal
+import com.alibaba.ttl.threadpool.agent.internal.logging.Logger
+import com.alibaba.ttl.threadpool.agent.internal.transformlet.ClassInfo
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.core.test.config.TestCaseConfig
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import javassist.bytecode.ClassFile
+import javassist.bytecode.ConstPool
+import java.io.ByteArrayInputStream
+import java.io.DataInputStream
+import java.util.function.BiConsumer
+import java.util.function.BiFunction
+import java.util.function.Consumer
+import java.util.function.Function
+import java.util.function.Supplier
+
+/**
+ * Tests for [TtlCompletionTransformlet], which instruments the `CompletableFuture$Completion`
+ * subclasses that hold user code (`UniApply`, `BiApply`, ...) so they replay the captured TTL
+ * context no matter whether they are triggered via `doExec` or `tryFire`.
+ */
+class TtlCompletionTransformletTest : AnnotationSpec() {
+    /**
+     * when run unit test under TTL agent,
+     * javassist is repackaged and excluded.
+     *
+     * skip this test case.
+     */
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun defaultTestCaseConfig(): TestCaseConfig = TestCaseConfig(enabled = noTtlAgentRun())
+
+    /**
+     * the transformlets hold a `static final Logger`, and [Logger.getLogger] throws unless the
+     * implementation type has been chosen (normally done by `TtlAgent.premain`).
+     */
+    @BeforeAll
+    fun beforeAll() {
+        Logger.setLoggerImplTypeIfNotSetYet("stderr")
+    }
+
+    @Test
+    fun doTransform_instruments_functional_completion_subclasses() {
+        // UniComposeExceptionally only exists on JDK 12+; filter to whatever this JDK actually has.
+        val simpleNames = listOf(
+            "UniApply", "UniAccept", "UniRun", "UniWhenComplete", "UniHandle", "UniExceptionally",
+            "UniComposeExceptionally", "UniCompose", "BiApply", "BiAccept", "BiRun",
+            "OrApply", "OrAccept", "OrRun"
+        )
+        val classNames = simpleNames.map { CF + it }.filter { isClassReadable(it) }
+
+        classNames.shouldNotBeEmpty()
+        listOf("UniApply", "UniAccept", "UniRun", "BiApply", "UniWhenComplete", "UniHandle").forEach {
+            classNames shouldContain (CF + it)
+        }
+
+        for (className in classNames) {
+            withClue(className) {
+                val classInfo = ClassInfo(className, classBytes(className), null)
+
+                newTransformlet().doTransform(classInfo)
+
+                classInfo.isModified shouldBe true
+                classInfo.ctClass.interfaces.map { it.name } shouldContain
+                    TtlCompletionTransformlet.Enhanced::class.java.name
+                classInfo.ctClass.toBytecode().isEmpty() shouldBe false
+            }
+        }
+    }
+
+    @Test
+    fun doTransform_leaves_functional_field_less_completion_subclasses_unmodified() {
+        // these run no user code, so TTL's plain doExec instrumentation must remain in effect
+        val simpleNames = listOf("Completion", "UniCompletion", "UniRelay", "BiCompletion", "CoCompletion", "Signaller", "AnyOf")
+        val classNames = simpleNames.map { CF + it }.filter { isClassReadable(it) }
+
+        classNames.shouldNotBeEmpty()
+
+        for (className in classNames) {
+            withClue(className) {
+                val classInfo = ClassInfo(className, classBytes(className), null)
+
+                newTransformlet().doTransform(classInfo)
+
+                classInfo.isModified shouldBe false
+            }
+        }
+    }
+
+    @Test
+    fun doTransform_ignores_non_completion_classes() {
+        val classNames = listOf(
+            CF + "AsyncSupply",
+            CF + "AsyncRun",
+            "java.util.concurrent.CompletableFuture",
+            "java.util.concurrent.ForkJoinTask",
+            "java.util.TimerTask"
+        )
+
+        for (className in classNames) {
+            withClue(className) {
+                val classInfo = ClassInfo(className, classBytes(className), null)
+
+                newTransformlet().doTransform(classInfo)
+
+                classInfo.isModified shouldBe false
+            }
+        }
+    }
+
+    @Test
+    fun doTransform_injects_the_type_specific_wrap_overload() {
+        data class Case(val simpleName: String, val expectedDescriptor: String)
+
+        val cases = listOf(
+            Case("UniApply", "(Ljava/util/function/Function;Ljava/lang/Object;)Ljava/util/function/Function;"),
+            Case("UniRun", "(Ljava/lang/Runnable;Ljava/lang/Object;)Ljava/lang/Runnable;"),
+            Case("UniWhenComplete", "(Ljava/util/function/BiConsumer;Ljava/lang/Object;)Ljava/util/function/BiConsumer;")
+        )
+
+        for ((simpleName, expectedDescriptor) in cases) {
+            withClue(simpleName) {
+                val className = CF + simpleName
+                val classInfo = ClassInfo(className, classBytes(className), null)
+
+                newTransformlet().doTransform(classInfo)
+
+                val bytecode = classInfo.ctClass.toBytecode()
+                val descriptors = wrapMethodDescriptors(bytecode)
+
+                // this is a regression guard: an (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+                // descriptor would mean the generic/Object wrap overload got called instead, which
+                // silently does not replay the captured context
+                descriptors shouldContain expectedDescriptor
+            }
+        }
+    }
+
+    @Test
+    fun findFunctionalField_returns_the_fn_field_or_null() {
+        val uniApplyName = CF + "UniApply"
+        val uniApply = ClassInfo(uniApplyName, classBytes(uniApplyName), null).ctClass
+        val fnField = TtlCompletionTransformlet.findFunctionalField(uniApply)
+
+        fnField.shouldNotBeNull()
+        fnField.name shouldBe "fn"
+        fnField.type.name shouldBe "java.util.function.Function"
+
+        val uniRelayName = CF + "UniRelay"
+        val uniRelay = ClassInfo(uniRelayName, classBytes(uniRelayName), null).ctClass
+        TtlCompletionTransformlet.findFunctionalField(uniRelay).shouldBeNull()
+    }
+
+    @Test
+    fun isCompletionSubclass_true_for_completion_subclass_false_otherwise() {
+        val uniApplyName = CF + "UniApply"
+        val uniApply = ClassInfo(uniApplyName, classBytes(uniApplyName), null).ctClass
+        TtlCompletionTransformlet.isCompletionSubclass(uniApply) shouldBe true
+
+        val asyncSupplyName = CF + "AsyncSupply"
+        val asyncSupply = ClassInfo(asyncSupplyName, classBytes(asyncSupplyName), null).ctClass
+        TtlCompletionTransformlet.isCompletionSubclass(asyncSupply) shouldBe false
+    }
+
+    @Test
+    fun wrap_Runnable_replays_captured_context_and_restores_after_run() {
+        val ttl = TransmittableThreadLocal<String>()
+        ttl.set("captured")
+        val captured = TransmittableThreadLocal.Transmitter.capture()
+        ttl.set("current")
+
+        var observed: String? = null
+        val wrapped = TtlCompletionTransformlet.wrap(Runnable { observed = ttl.get() }, captured)
+
+        wrapped.run()
+
+        observed shouldBe "captured"
+        ttl.get() shouldBe "current"
+        ttl.remove()
+    }
+
+    @Test
+    fun wrap_Runnable_restores_even_when_the_wrapped_fn_throws() {
+        val ttl = TransmittableThreadLocal<String>()
+        ttl.set("captured")
+        val captured = TransmittableThreadLocal.Transmitter.capture()
+        ttl.set("current")
+
+        val wrapped = TtlCompletionTransformlet.wrap(Runnable { throw RuntimeException("boom") }, captured)
+
+        shouldThrow<RuntimeException> { wrapped.run() }
+
+        ttl.get() shouldBe "current"
+        ttl.remove()
+    }
+
+    @Test
+    fun wrap_Function_replays_restores_and_passes_argument_and_return_value_through() {
+        val ttl = TransmittableThreadLocal<String>()
+        ttl.set("captured")
+        val captured = TransmittableThreadLocal.Transmitter.capture()
+        ttl.set("current")
+
+        var observed: String? = null
+        val wrapped = TtlCompletionTransformlet.wrap(Function<String, String> { arg -> observed = ttl.get(); "$arg!" }, captured)
+
+        wrapped.apply("hi") shouldBe "hi!"
+        observed shouldBe "captured"
+        ttl.get() shouldBe "current"
+        ttl.remove()
+    }
+
+    @Test
+    fun wrap_Consumer_replays_restores_and_passes_argument_through() {
+        val ttl = TransmittableThreadLocal<String>()
+        ttl.set("captured")
+        val captured = TransmittableThreadLocal.Transmitter.capture()
+        ttl.set("current")
+
+        var observedArg: String? = null
+        var observedTtl: String? = null
+        val wrapped = TtlCompletionTransformlet.wrap(
+            Consumer<String> { arg -> observedArg = arg; observedTtl = ttl.get() },
+            captured
+        )
+
+        wrapped.accept("hi")
+
+        observedArg shouldBe "hi"
+        observedTtl shouldBe "captured"
+        ttl.get() shouldBe "current"
+        ttl.remove()
+    }
+
+    @Test
+    fun wrap_BiFunction_replays_restores_and_passes_arguments_and_return_value_through() {
+        val ttl = TransmittableThreadLocal<String>()
+        ttl.set("captured")
+        val captured = TransmittableThreadLocal.Transmitter.capture()
+        ttl.set("current")
+
+        var observed: String? = null
+        val wrapped = TtlCompletionTransformlet.wrap(
+            BiFunction<String, String, String> { a, b -> observed = ttl.get(); "$a-$b" },
+            captured
+        )
+
+        wrapped.apply("x", "y") shouldBe "x-y"
+        observed shouldBe "captured"
+        ttl.get() shouldBe "current"
+        ttl.remove()
+    }
+
+    @Test
+    fun wrap_BiConsumer_replays_restores_and_passes_arguments_through() {
+        val ttl = TransmittableThreadLocal<String>()
+        ttl.set("captured")
+        val captured = TransmittableThreadLocal.Transmitter.capture()
+        ttl.set("current")
+
+        var observedArgs: Pair<String, String>? = null
+        var observedTtl: String? = null
+        val wrapped = TtlCompletionTransformlet.wrap(
+            BiConsumer<String, String> { a, b -> observedArgs = a to b; observedTtl = ttl.get() },
+            captured
+        )
+
+        wrapped.accept("x", "y")
+
+        observedArgs shouldBe ("x" to "y")
+        observedTtl shouldBe "captured"
+        ttl.get() shouldBe "current"
+        ttl.remove()
+    }
+
+    @Test
+    fun every_supported_functional_interface_has_a_dedicated_wrap_overload() {
+        // The catch-all wrap(T, Object) hands fn back unwrapped, so a type listed as supported but
+        // missing a real overload would silently stop replaying context for that completion stage.
+        // findFunctionalField matches on this list, so the two must stay in lockstep.
+        val overloadFirstParameterTypes = TtlCompletionTransformlet::class.java.methods
+            .filter { it.name == "wrap" }
+            .map { it.parameterTypes[0].name }
+
+        TtlCompletionTransformlet.supportedFunctionalInterfaces.shouldNotBeEmpty()
+        for (functionalInterface in TtlCompletionTransformlet.supportedFunctionalInterfaces) {
+            withClue(functionalInterface) {
+                overloadFirstParameterTypes shouldContain functionalInterface
+            }
+        }
+    }
+
+    @Test
+    fun findFunctionalField_ignores_functional_types_without_a_wrap_overload() {
+        // AsyncSupply holds `Supplier<? extends T> fn`: a @FunctionalInterface, but one with no wrap
+        // overload. Matching it would route through the catch-all and silently not replay, so the
+        // whitelist must reject it. (AsyncSupply is not a Completion either, but findFunctionalField
+        // is the layer that has to be type-safe here.)
+        val className = CF + "AsyncSupply"
+        val asyncSupply = ClassInfo(className, classBytes(className), null).ctClass
+
+        withClue("precondition: AsyncSupply.fn is still a Supplier on this JDK") {
+            asyncSupply.getDeclaredField("fn").type.name shouldBe "java.util.function.Supplier"
+        }
+        TtlCompletionTransformlet.findFunctionalField(asyncSupply).shouldBeNull()
+    }
+
+    @Test
+    fun catch_all_wrap_returns_the_function_unwrapped() {
+        val ttl = TransmittableThreadLocal<String>()
+        ttl.set("captured")
+        val captured = TransmittableThreadLocal.Transmitter.capture()
+        ttl.set("current")
+
+        // Supplier has no dedicated overload, so this binds to the catch-all wrap(T, Object)
+        val fn = Supplier { ttl.get() }
+        val wrapped: Supplier<String> = TtlCompletionTransformlet.wrap(fn, captured)
+
+        withClue("the catch-all must hand back the original instance, not a replaying wrapper") {
+            wrapped shouldBeSameInstanceAs fn
+        }
+        withClue("and so must NOT replay the captured context -- it logs at SEVERE instead") {
+            wrapped.get() shouldBe "current"
+        }
+        ttl.remove()
+    }
+}
+
+private const val CF = "java.util.concurrent.CompletableFuture$"
+
+private fun newTransformlet(): TtlCompletionTransformlet {
+    return TtlCompletionTransformlet()
+}
+
+private fun classBytes(binaryName: String): ByteArray =
+    ClassLoader.getSystemResourceAsStream(binaryName.replace('.', '/') + ".class")!!.use { it.readBytes() }
+
+private fun isClassReadable(binaryName: String): Boolean =
+    ClassLoader.getSystemResourceAsStream(binaryName.replace('.', '/') + ".class")?.also { it.close() } != null
+
+/**
+ * The methodref descriptors of every constant-pool `wrap` method reference in [classBytecode],
+ * i.e. which overload of [TtlCompletionTransformlet.wrap] the injected code actually resolved to.
+ */
+private fun wrapMethodDescriptors(classBytecode: ByteArray): List<String> {
+    val classFile = ClassFile(DataInputStream(ByteArrayInputStream(classBytecode)))
+    val cp = classFile.constPool
+
+    val descriptors = mutableListOf<String>()
+    for (i in 1 until cp.size) {
+        try {
+            if (cp.getTag(i) == ConstPool.CONST_Methodref && cp.getMethodrefName(i) == "wrap") {
+                descriptors += cp.getMethodrefType(i)
+            }
+        } catch (expected: Exception) {
+            // some constant-pool slots (e.g. the second half of a Long/Double entry) are not
+            // readable via these accessors; skip them
+        }
+    }
+    return descriptors
+}


### PR DESCRIPTION
Fixes #825 

## Problem description

`CompletableFuture.Completion` extends `ForkJoinTask`, so we expect TTL to replay the captured context when executing completion stages. The problem is that after completion, `CompletableFuture` may greedily execute its dependent stages via the `tryFire` method, bypassing the `ForkJoinTask.doExec` interface. Because TTL only instruments `doExec`, these dependent stages execute without the replay/restore logic and therefore read the wrong context. This issue arises whenever we use non-async methods, e.g. `CompletableFuture.thenCompose`, `CompletableFuture.thenApply`, and `CompletableFuture.handle`.

<img height="600" alt="Image" src="https://github.com/user-attachments/assets/d6d99315-7203-4906-a172-e8e108fe3928" />